### PR TITLE
Added Slack ownership to test page expiry

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -17,3 +17,11 @@ google_site_verification: "IJ5HOXpZrISM6la-YO_iX0rBUC5YFftpexygcKLsNs4"
 # Multi-page options
 multipage_nav: true
 collapsible_nav: true
+
+# Show links to contribute on GitHub
+show_contribution_banner: true
+github_repo: alphagov/tdt-documentation
+
+# Ownership for page reviews
+default_owner_slack: '#docs-repos'
+owner_slack_workspace: gds

--- a/source/support/index.html.md.erb
+++ b/source/support/index.html.md.erb
@@ -1,7 +1,8 @@
 ---
 title: Support
 weight: 80
+last_reviewed_on: 2018-11-27
+review_in: 1 day
 ---
 
 # Support
-


### PR DESCRIPTION
* set `owner_slack:` to the github alerts channel to test out page expiry
* set `last_reviewed_on: 2018-11-27` and `review_in: 1 day` to see what this looks like in the front end

@bravegrape @bahmady