### PR TITLE
Set GOV.UK crown logo to false

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -37,3 +37,6 @@ enable_search: true
 # Ownership for page reviews
 default_owner_slack: '#docs-repos'
 owner_slack_workspace: gds
+
+# Enable GOV.UK crown logo
+show_govuk_logo: false


### PR DESCRIPTION
### Context

Cannot show crown logo without a `.gov.uk` url.

### Changes proposed in this pull request

Add flag to config.yml and set to false

### Guidance to review
