### PR TITLE
Bundle exec middleman server

### DIFF
--- a/source/preview/temp_version.md
+++ b/source/preview/temp_version.md
@@ -63,3 +63,18 @@ Autopilot is a Cloud Foundry plugin for zero-downtime app deployment.
 1. Run `cf apps` to check your new app appears in the targeted org and space. 
 
 1. Check your app has deployed by going to ` NEW_APP_NAME_TO_BE_DEPLOYED.cloudapps.digital`.
+
+# Preview from your local machine
+
+You can preview your documentation from your local machine.
+
+Run the following from the documentation repo folder on your local machine:
+
+```
+bundle exec middleman server
+```
+
+Go to your internet browser and navigate to `http://localhost:4567/` to preview your documentation.
+
+You can change your content files and see the documentation update immediately.
+


### PR DESCRIPTION
### Context

Run `bundle exec middleman server` to preview your content from your local machine.

### Changes proposed in this pull request

Run `bundle exec middleman server` to preview your content from your local machine.

### Guidance to review
