### PR TITLE
Include site config & frontmatter docs

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,3 +1,18 @@
 require 'govuk_tech_docs'
 
 GovukTechDocs.configure(self, livereload: { js_host: "localhost" })
+
+DOCS_LOCATION_IN_GEM = Bundler.rubygems.find_name('govuk_tech_docs').first.full_gem_path + "/docs"
+
+files.watch :source, path: DOCS_LOCATION_IN_GEM
+
+helpers do
+  def gem_docs(filename)
+    raw_markdown = File.read(DOCS_LOCATION_IN_GEM + "/#{filename}")
+
+    # Strip the h1 header from the original markdown file
+    markdown = raw_markdown.lines[1..-1].join
+
+    markdown
+  end
+end

--- a/source/configuration-options.html.md.erb
+++ b/source/configuration-options.html.md.erb
@@ -1,0 +1,7 @@
+---
+title: Configuration options
+---
+
+# Configuration options
+
+<%= gem_docs 'configuration.md' %>

--- a/source/frontmatter.html.md.erb
+++ b/source/frontmatter.html.md.erb
@@ -1,0 +1,7 @@
+---
+title: Frontmatter
+---
+
+# Frontmatter
+
+<%= gem_docs 'frontmatter.md' %>


### PR DESCRIPTION
This includes two pieces of documentation from the gem directly into
this site:

https://github.com/alphagov/tech-docs-gem/blob/master/docs/configuration.md
https://github.com/alphagov/tech-docs-gem/blob/master/docs/frontmatter.md

The advantage of pulling in the markdown files like this is that developers can update the code and docs in a single PR, which makes it less likely the docs are forgotten.

This is part of the now deprecated https://github.com/alphagov/tech-docs-manual.
