### PR TITLE
Adds a section pointing to important Middleman docs 

### DIFF
--- a/source/middleman.html.md.erb
+++ b/source/middleman.html.md.erb
@@ -1,0 +1,18 @@
+---
+title: Middleman options
+weight: 87
+---
+
+# Middleman options
+
+The GDS technical documentation tool is built with
+[Middleman](https://middlemanapp.com/) [external link], so it offers all the same
+functionality. Much of this is not specific to the tool itself.
+
+For example, you can read Middleman's own documentation about:
+
+* how to set up [redirects](https://middlemanapp.com/basics/redirects/)
+* the development cycle, and [how to run a local version of your site](https://middlemanapp.com/basics/development-cycle/)
+* how to [build your site](https://middlemanapp.com/basics/build-and-deploy/)
+
+[external links]


### PR DESCRIPTION
### Context
We need some information about redirects, but also about running locally and building. We shouldn't necessarily describe this in detail ourselves since Middleman also has good documentation about this, but we haven't decided this for sure—this could always be iterated on in future

### Changes proposed in this pull request
Adds a new section pointing to relevant Middleman documentation that isn't already covered in existing documentation / is unlikely to ever be 

### Guidance to review
Might be worth removing the 'Frontmatter' section or changing it if we add this section, since Middleman has a lot of guidance about that and I'm not sure how much of it is tool-specific: https://middlemanapp.com/basics/frontmatter/