### PR TITLE
Left hand nav and update ruby gems

### DIFF
--- a/source/api_ref.html.md.erb
+++ b/source/api_ref.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: API reference
+title: "API reference"
 weight: 80
 ---
 

--- a/source/architecture/multipage.md
+++ b/source/architecture/multipage.md
@@ -39,9 +39,13 @@ You must amend the documentation repo folder structure to reflect this structure
 
 Basic multipage requires multiple `.html.md.erb` files in the tech docs repo __source__ folder.
 
-Each `.html.md.erb` file relates to one separate page within the tech docs, and references the markdown files in the associated folder. 
+Each `.html.md.erb` file relates to one separate page within the tech docs, and references the markdown files in the associated folder.
 
 Additionally, the tech doc repo must have at least one `.html.md.erb` file in the __source__ folder named `index.html.md.erb`.
+
+The .html.md.erb files must not have the same name as the folders that the .html.md.erb files use partials refer to.
+
+For example, you cannot have a support.html.md.erb file that contains the partial `<%= partial 'support/contact_us' %>`.
 
 ### Amend the multiple .html.md.erb files
 
@@ -65,20 +69,20 @@ Additionally, the tech doc repo must have at least one `.html.md.erb` file in th
     ```
 
     Higher weights mean that the content is lower down in the documentation hierarchy. An easy way to remember this is to think “heavier pages sink to the bottom”.
-  
+
     For example, a single `.html.md.erb` file becomes multiple `.html.md.erb` files:
-    
+
     <div style="height:1px;font-size:1px;">&nbsp;</div>
-    
+
     |Single page|Multipage|
     |:---|:---|
     |---<br>weight: 10<br>title: "Product Technical Documentation"<br>---<br><br><%= partial 'documentation/index' %>|---<br>weight: 10<br>title: "Product Technical Documentation"<br>---<br><br><%= partial 'documentation/index' %>|
     ||---<br>weight: 10<br>title: "Product Technical Documentation"<br>---<br><br><%= partial 'documentation/index' %>|
     ||---<br>weight: 20<br>title: "Product Technical Documentation"<br>---<br><br><%= partial 'documentation/start' %>|
     ||---<br>weight: 30<br>title: "Product Technical Documentation"<br>---<br><br><%= partial 'documentation/users' %>|
-  
+
     <div style="height:1px;font-size:1px;">&nbsp;</div>
-  
+
 ### Add H1 heading if required
 
 Add an H1 heading to either the `.html.md.erb` file or at the start of the first markdown file for each individual content page.
@@ -121,7 +125,7 @@ You must amend the documentation repo folder structure to reflect this structure
 
 Basic multipage requires multiple `.html.md.erb` files in the tech docs repo __source__ folder.
 
-Each `.html.md.erb` file relates to one separate page within the tech docs, and references the markdown files in the associated folder. 
+Each `.html.md.erb` file relates to one separate page within the tech docs, and references the markdown files in the associated folder.
 
 Additionally, the tech doc repo must have at least one `.html.md.erb` file in the __source__ folder named `index.html.md.erb`.
 
@@ -147,20 +151,20 @@ Additionally, the tech doc repo must have at least one `.html.md.erb` file in th
     ```
 
     Higher weights mean that the content is lower down in the documentation hierarchy. An easy way to remember this is to think “heavier pages sink to the bottom”.
-  
+
     For example, a single `.html.md.erb` file becomes multiple `.html.md.erb` files:
-  
+
     <div style="height:1px;font-size:1px;">&nbsp;</div>
-  
+
     |Single page|Multipage|
     |:---|:---|
     |---<br>weight: 10<br>title: "Product Technical Documentation"<br>---<br><br><%= partial 'documentation/index' %>|---<br>weight: 10<br>title: "Product Technical Documentation"<br>---<br><br><%= partial 'documentation/index' %>|
     ||---<br>weight: 10<br>title: "Product Technical Documentation"<br>---<br><br><%= partial 'documentation/index' %>|
     ||---<br>weight: 20<br>title: "Product Technical Documentation"<br>---<br><br><%= partial 'documentation/start' %>|
     ||---<br>weight: 30<br>title: "Product Technical Documentation"<br>---<br><br><%= partial 'documentation/users' %>|
-  
+
     <div style="height:1px;font-size:1px;">&nbsp;</div>
-  
+
 ### Add H1 heading if required
 
 Add an H1 heading to either the `.html.md.erb` file or at the start of the first markdown file for each individual content page.
@@ -169,7 +173,7 @@ If there is an H1 heading in both, you will see two H1s when the documentation s
 
 ### Create folder for nested content .html.md.erb files
 
-Refer to the GOV.UK PaaS technical documentation repo [nested content folder](https://github.com/alphagov/paas-tech-docs/tree/master/source/deploying_services) as an example. 
+Refer to the GOV.UK PaaS technical documentation repo [nested content folder](https://github.com/alphagov/paas-tech-docs/tree/master/source/deploying_services) as an example.
 
 1. Create a folder within the __source__ folder. This is where the `.html.md.erb` files for your nested content must live.
 
@@ -177,18 +181,14 @@ Refer to the GOV.UK PaaS technical documentation repo [nested content folder](ht
 
     Note that each `.html.md.erb` must have a weight value that preserves the overall hierarchy both within the nested content and compared to the other non-nested content.
 
-1. Create sub-folders for each nested page under the "wrapper". 
+1. Create sub-folders for each nested page under the "wrapper".
 
 1. Create an `index.html.md.erb` file within each sub-folder. Each `.html.md.erb` file can refer to another content file through partials or have the content in itself.
 
     Note that each `.html.md.erb` file must have a weight value that preserves the overall hierarchy both within the nested content and compared to the other non-nested content.
-    
+
 ### Add H1 heading if required
 
 Add an H1 heading to either the `.html.md.erb` file or at the start of the first markdown file for each individual content page.
 
 If there is an H1 heading in both, you will see two H1s when the documentation site builds and renders in your internet browser.
-
-
-
-

--- a/source/architecture/single_page.md
+++ b/source/architecture/single_page.md
@@ -4,7 +4,7 @@ You can create a technical documentation site that contains all of its content i
 
 This is suitable for documentation sites that have do not have a lot of content, and do not need to have topics split into individual pages.
 
-## Organise content files 
+## Organise content files
 
 1. [Create](create_new_project.html#create-a-new-project) the content files for your documentation site.
 
@@ -18,14 +18,18 @@ This is suitable for documentation sites that have do not have a lot of content,
 
 1. Select the `index.html.md.erb` file.
 
-1. Amend the `index.html.md.erb` file. 
+1. Amend the `index.html.md.erb` file.
 
     You can either [add a `<%= partial` line](single_page.html#add-partial-lines) that references each content file that makes up your overall documentation site, or add the content into the `index.html.md.erb` file directly.
 
-### Add partial lines 
+    The .html.md.erb files must not have the same name as the folders that the .html.md.erb files use partials refer to.
+
+    For example, you cannot have a support.html.md.erb file that contains the partial `<%= partial 'support/contact_us' %>`.
+
+### Add partial lines
 
 In this example, you have three content files:
-  
+
 - an introduction named `index.md` in the `documentation` folder
 - a "Who is this documentation for?" section named `who-docs.md` in the `documentation/introduction` folder
 - a "Set up the API client" section named `set_up_client` in the `documentation/introduction` folder

--- a/source/collapsible_nav.html.md.erb
+++ b/source/collapsible_nav.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Collapsible navigation
+title: "Collapsible navigation"
 weight: 70
 ---
 

--- a/source/configuration-options.html.md.erb
+++ b/source/configuration-options.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Configuration options
+title: "Configuration options"
 ---
 
 # Configuration options

--- a/source/create_new_project.html.md.erb
+++ b/source/create_new_project.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: GDS technical documentation tool
+title: "Create a new project"
 weight: 30
 ---
 

--- a/source/frontmatter.html.md.erb
+++ b/source/frontmatter.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Frontmatter
+title: "Frontmatter"
 ---
 
 # Frontmatter

--- a/source/functionality/update_gem.md
+++ b/source/functionality/update_gem.md
@@ -1,0 +1,72 @@
+# Update docs to use latest tech-docs-gem
+
+## Clone the remote documentation repo
+
+1. Open your internet browser and go to your remote documentation repo on GitHub.
+
+1. Select the __Clone or download__ button.
+
+1. Select either __Use HTTPS__ or __Use SSH__.
+
+1. Select the copy button.
+
+1. In the command line, clone the remote repo to a local directory:
+
+    ```
+    git clone [repo address]
+    ```
+
+## Create a new branch
+
+1. Go into the cloned local repo folder using the command line.
+
+1. Check that you are on the master branch:
+
+    ```
+    git status
+    ```
+
+    You should get the message:
+
+    ```
+    On branch master
+    Your branch is up to date with 'origin/master'.
+    nothing to commit, working tree clean
+    ```
+1. Create a new branch and switch to that branch:
+
+    ```
+    git checkout -b [BRANCH_NAME]
+    ```
+
+## Update the ruby gems in the documentation repo
+
+1. Update all ruby gems:
+
+    ```
+    bundle update
+    ```
+
+    This updates all the ruby gems that your documentation repo uses, including the `tech-docs-gem`.
+
+    You should get the message `Bundle updated!` once the update is finished.
+
+1. Add all changes to the next commit:
+
+    ```
+    git add .
+    ```
+
+1. Commit the changes:
+
+    ```
+    git commit -m "[commit message]"
+    ```
+    where `COMMIT_MESSAGE` is the description of the commit.
+
+1. Push the new branch to the remote documentation repo on GitHub:
+
+    ```
+    git push -u origin [BRANCH NAME]
+    ```
+1. Review, approve and merge the changes in line with your service team processes.

--- a/source/functionality/update_gem.md
+++ b/source/functionality/update_gem.md
@@ -16,38 +16,15 @@
     git clone [repo address]
     ```
 
-## Create a new branch
-
-1. Go into the cloned local repo folder using the command line.
-
-1. Check that you are on the master branch:
-
-    ```
-    git status
-    ```
-
-    You should get the message:
-
-    ```
-    On branch master
-    Your branch is up to date with 'origin/master'.
-    nothing to commit, working tree clean
-    ```
-1. Create a new branch and switch to that branch:
-
-    ```
-    git checkout -b [BRANCH_NAME]
-    ```
-
 ## Update the ruby gems in the documentation repo
 
-1. Update all ruby gems:
+1. Update all ruby gems in the cloned local documentation repo:
 
     ```
     bundle update
     ```
 
-    This updates all the ruby gems that your documentation repo uses, including the `tech-docs-gem`.
+    This updates all the ruby gems that your repo uses, including the `tech-docs-gem`.
 
     You should get the message `Bundle updated!` once the update is finished.
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: GDS technical documentation tool
+title: "GDS technical documentation tool"
 weight: 10
 ---
 

--- a/source/install_macs.html.md.erb
+++ b/source/install_macs.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: GDS technical documentation tool
+title: "Prerequisites for Macs"
 weight: 20
 ---
 

--- a/source/middleman.html.md.erb
+++ b/source/middleman.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Middleman options
+title: "Middleman options"
 weight: 87
 ---
 

--- a/source/multipage.html.md.erb
+++ b/source/multipage.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Multipage
+title: "Multipage"
 weight: 50
 ---
 

--- a/source/publish.html.md.erb
+++ b/source/publish.html.md.erb
@@ -1,6 +1,0 @@
----
-title: Publish your documentation
-weight: 85
----
-
-<%= partial 'publish/push-repo' %>

--- a/source/publish/push_repo.md
+++ b/source/publish/push_repo.md
@@ -1,5 +1,10 @@
 # Publish your documentation
 
+To publish your documentation, you must:
+
+- push your documentation to the remote GitHub repo
+- deploy your site
+
 ## Push documentation to GitHub
 
 These instructions assume that you have documentation changes ready to push to GitHub.
@@ -30,7 +35,7 @@ To push your documentation changes to GitHub for the first time, you must:
 1. If applicable, add all files in the local repo and stage them for commit:
 
     ```
-    git add
+    git add .
     ```
 
 1. Commit the staged files:
@@ -99,8 +104,4 @@ you deploy your site with GitHub Pages.
 
 ## Continuous integration
 
-The GOV.UK PaaS documentation explains how to set up continuous
-integration (CI) with [Travis and
-Jenkins](https://docs.cloud.service.gov.uk/using_ci.html#using-the-travis-ci-tool).
-We recommend this method for documentation sites built using the GDS technical
-documentation tool.
+The GOV.UK PaaS documentation explains how to set up continuous integration (CI) with [Travis and Jenkins](https://docs.cloud.service.gov.uk/using_ci.html#using-the-travis-ci-tool). We recommend this method for documentation sites built using the GDS technical documentation tool.

--- a/source/publish_docs.html.md.erb
+++ b/source/publish_docs.html.md.erb
@@ -1,0 +1,6 @@
+---
+title: "Publish your documentation"
+weight: 85
+---
+
+<%= partial 'publish/push_repo' %>

--- a/source/search.html.md.erb
+++ b/source/search.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Search
+title: "Search"
 weight: 60
 ---
 

--- a/source/single_page.html.md.erb
+++ b/source/single_page.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Single Page
+title: "Single Page"
 weight: 40
 ---
 

--- a/source/support_info.html.md.erb
+++ b/source/support_info.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Support
+title: "Support"
 weight: 90
 last_reviewed_on: 2018-11-25
 review_in: 1 day

--- a/source/update_gem.html.md.erb
+++ b/source/update_gem.html.md.erb
@@ -1,0 +1,6 @@
+---
+title: "Update ruby gems"
+weight: 55
+---
+
+<%= partial 'functionality/update_gem' %>

--- a/source/warning.html.md.erb
+++ b/source/warning.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Warning
+title: "Warning"
 weight: 71
 ---
 


### PR DESCRIPTION
### Context

The left hand nav in the support and publish sections were not displaying correctly. This was driven by the relevant *.html.md.erb files having the same name as the folders that the .html.md.erb files use partials to refer to. For example, you cannot have a support.html.md.erb file that contains the partial `<%= partial 'support/contact_us' %>`.

Corrected this error and added guidance into the single and multipage sections to this effect. Also added in content on updating ruby gems.

### Changes proposed in this pull request

- Correct left hand nav by renaming subfolders. 
- Add in guidance on .html.md.erb filenames being different to subfolders they refer to. 
- Add in guidance to update all ruby gems in repo.

### Guidance to review
