### PR TITLE
Removes FAQ format from intro

### DIFF
--- a/source/introduction/introduction.md
+++ b/source/introduction/introduction.md
@@ -1,6 +1,6 @@
-# Introduction
+# The GDS technical documentation tool
 
-## What is the GDS technical documentation tool?
+## What you can use this tool for
 
 This tool is a template for technical and developer documentation.
 
@@ -8,7 +8,7 @@ It uses the [Middleman static site generator](https://middlemanapp.com/) [extern
 
 It is suitable for multiple styles of documentation, including API documentation.
 
-## Why should you use this?
+## Why you should use this tool
 
 It promotes consistency on technical documentation which should reassure end users.
 
@@ -16,10 +16,6 @@ It helps technical writers manage their technical content using the [‘docs as 
 
 This documentation is currently under construction.
 
-## Who should use the tool?
+## Who should use this tool
 
 The GDS technical documentation tool is intended for internal use by the GDS and government community.
-
-## Who is this documentation website for?
-
-The content in this documentation website is intended for internal use by the GDS and government community.


### PR DESCRIPTION
### Context
We should remove FAQs from the TDT

### Changes proposed in this pull request
Changes FAQ format to statement format in introduction, renames title to 'GDS technical documentation tool', removes duplicate