### PR TITLE
[DISCUSS] Rename to "Tech Docs Template"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Documentation for the GDS technical documentation tool (GDS TDT)
+# Tech Docs Template Documentation
 
 [![Build Status](https://travis-ci.org/alphagov/tdt-documentation.svg?branch=master)](https://travis-ci.org/alphagov/tdt-documentation)
 

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -3,7 +3,7 @@ host: https://tdt-documentation.london.cloudapps.digital/
 
 # Header-related options
 show_govuk_logo: true
-service_name: GDS documentation tool
+service_name: Tech docs template
 service_link:
 phase: Beta
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: "GDS technical documentation tool"
+title: "Tech Docs Template"
 weight: 10
 ---
 

--- a/source/introduction/introduction.md
+++ b/source/introduction/introduction.md
@@ -1,4 +1,4 @@
-# The GDS technical documentation tool
+# Tech Docs Template
 
 ## What you can use this tool for
 
@@ -18,4 +18,4 @@ This documentation is currently under construction.
 
 ## Who should use this tool
 
-The GDS technical documentation tool is intended for internal use by the GDS and government community.
+The Tech Docs Template is intended for internal use by the GDS and government community.

--- a/source/middleman.html.md.erb
+++ b/source/middleman.html.md.erb
@@ -5,7 +5,7 @@ weight: 87
 
 # Middleman options
 
-The GDS technical documentation tool is built with
+The Tech Docs Template is built with
 [Middleman](https://middlemanapp.com/) [external link], so it offers all the same
 functionality. Much of this is not specific to the tool itself.
 

--- a/source/publish/push_repo.md
+++ b/source/publish/push_repo.md
@@ -82,7 +82,7 @@ For more information, refer to [Adding an existing project to GitHub](https://he
 
 ## Deploy your site
 
-The GDS technical documentation tool is built on Middleman, which is a static
+The Tech Docs Template is built on Middleman, which is a static
 site generator. You can therefore deploy your site anywhere that supports
 static sites.
 
@@ -90,7 +90,7 @@ static sites.
 
 We recommend that government services use the [GOV.UK
 PaaS](https://www.cloud.service.gov.uk/) to deploy documentation sites built
-with the GDS technical documentation tool. This is also free of charge for
+with the Tech Docs Template. This is also free of charge for
 government services.
 
 ### GitHub Pages
@@ -104,4 +104,4 @@ you deploy your site with GitHub Pages.
 
 ## Continuous integration
 
-The GOV.UK PaaS documentation explains how to set up continuous integration (CI) with [Travis and Jenkins](https://docs.cloud.service.gov.uk/using_ci.html#using-the-travis-ci-tool). We recommend this method for documentation sites built using the GDS technical documentation tool.
+The GOV.UK PaaS documentation explains how to set up continuous integration (CI) with [Travis and Jenkins](https://docs.cloud.service.gov.uk/using_ci.html#using-the-travis-ci-tool). We recommend this method for documentation sites built using the Tech Docs Template.


### PR DESCRIPTION
In other repos, this project is named "Tech Docs Template". We should be consistent, so I suggest we either rename this particular repo, or rename it in the other repos:

- https://github.com/alphagov/tech-docs-template
- https://github.com/alphagov/tech-docs-gem
- https://github.com/alphagov/tech-docs-monitor

I may have missed a discussion about the branding of the project, so putting this up for discussion.