### PR TITLE
Tweak installations instructions

### DIFF
--- a/source/getting_started/install_macs.md
+++ b/source/getting_started/install_macs.md
@@ -12,7 +12,9 @@ You must also have a [GitHub account](https://github.com/) [external link] with 
 
 ## Administrator rights on your laptop
 
-If your in GDS, [sd-community@digital.cabinet-office.gov.uk](mailto:sd-community@digital.cabinet-office.gov.uk) to request administrator rights on your laptop.
+Email [sd-community@digital.cabinet-office.gov.uk](mailto:sd-community@digital.cabinet-office.gov.uk) to request administrator rights on your laptop.
+
+You must be a Government Digital Service employee to do this.
 
 ## Install text editor
 

--- a/source/getting_started/install_macs.md
+++ b/source/getting_started/install_macs.md
@@ -13,7 +13,7 @@ You must also have a [GitHub account](https://github.com/) [external link] with 
 
 ## Administrator rights on your laptop
 
-Email [sd-community@digital.cabinet-office.gov.uk](mailto:sd-community@digital.cabinet-office.gov.uk) to request administrator rights on your laptop.
+If your in GDS, [sd-community@digital.cabinet-office.gov.uk](mailto:sd-community@digital.cabinet-office.gov.uk) to request administrator rights on your laptop.
 
 ## Install text editor
 

--- a/source/getting_started/install_macs.md
+++ b/source/getting_started/install_macs.md
@@ -6,7 +6,6 @@ You must have the following set up on your mac laptop:
 - text editor
 - [Xcode](https://developer.apple.com/xcode/) command line interface tools [external link]
 - [Ruby](https://www.ruby-lang.org/en/) [external link]
-- [Bundler](https://bundler.io/) [external link]
 - [Middleman](https://middlemanapp.com/) static site generator [external link]
 
 You must also have a [GitHub account](https://github.com/) [external link] with access to alphagov at `https://github.com/alphagov/paas-tech-docs`.

--- a/source/getting_started/install_macs.md
+++ b/source/getting_started/install_macs.md
@@ -59,17 +59,3 @@ Run the following in the command line interface to install Middleman:
 ```
 gem install middleman
 ```
-
-## Download the `govuk_tech_docs ` Gem
-
-The tool is [hosted on
-Rubygems](https://rubygems.org/gems/govuk_tech_docs/versions/1.5.0) [external
-link].
-
-You should include the following in your project Gemfile to use the tool:
-
-`gem 'govuk_tech_docs'`
-
-Then install [using Bundler](#install-bundler). Run the following in your project directory:
-
-`bundle install`

--- a/source/getting_started/install_macs.md
+++ b/source/getting_started/install_macs.md
@@ -48,17 +48,7 @@ You can install Ruby in multiple ways, for example using [Ruby Version Manager](
     `\curl -sSL https://get.rvm.io | bash -s stable --ruby`
     ```
 
-1. Run `rvm install ruby-x.x.x` to install the latest version of [Ruby](https://www.ruby-lang.org/en/). The current x.x.x is `2.5.1`.
-
-## Install Bundler
-
-[Bundler](https://bundler.io/) [external link] is installed globally. This means that you can run the install command from any location on your local machine rather than from within a specific folder.
-
-Run the following in the command line interface to install Bundler:
-
-```
-gem install bundler
-```
+1. Run `rvm install ruby-x.x.x` to install the latest version of [Ruby](https://www.ruby-lang.org/en/). The current x.x.x is `2.6.1`.
 
 ## Install Middleman
 


### PR DESCRIPTION
See commits for details:

- Make clear that requesting admin rights is something that only GDS people can do 
- Recommend installing Ruby 2.6.1 so that we don't need to install bundler
- Don't separately install `govuk_tech_docs` gem 