### PR TITLE
Add basic authentication

### DIFF
--- a/source/publish/push_repo.md
+++ b/source/publish/push_repo.md
@@ -102,6 +102,27 @@ tool](https://github.com/edgecase/middleman-gh-pages), which we do not
 support. We also cannot guarantee that all features of the tool will work if
 you deploy your site with GitHub Pages.
 
+### Add basic authentication
+
+There are many ways to add basic authentication to your documentation site. 
+
+The following instructions apply if you:
+
+- want to deploy your documentation site on the GOV.UK PaaS
+- only have to push your documentation site to the GOV.UK PaaS once, for example if it is a temporary site to review a content change
+
+1. In the command line, navigate to your local documentation repo.
+
+1. If required, run `bundle exec middleman build` to create a `build` folder.
+
+1. Create a new `Staticfile.auth` file in the `build` folder.
+
+1. Go to the [Htpasswd Generator](http://www.htaccesstools.com/htpasswd-generator). 
+
+1. Complete the __Username__ and __Password__ fields, and select __Create .htpasswd file__. 
+
+1. Copy the generated username and password hash into the `Staticfile.auth` file and save.
+
 ## Continuous integration
 
 The GOV.UK PaaS documentation explains how to set up continuous integration (CI) with [Travis and Jenkins](https://docs.cloud.service.gov.uk/using_ci.html#using-the-travis-ci-tool). We recommend this method for documentation sites built using the Tech Docs Template.

--- a/source/publish/push_repo.md
+++ b/source/publish/push_repo.md
@@ -123,6 +123,8 @@ The following instructions apply if you:
 
 1. Copy the generated username and password hash into the `Staticfile.auth` file and save.
 
+1. Deploy your documentation site in line with your normal process.
+
 ## Continuous integration
 
 The GOV.UK PaaS documentation explains how to set up continuous integration (CI) with [Travis and Jenkins](https://docs.cloud.service.gov.uk/using_ci.html#using-the-travis-ci-tool). We recommend this method for documentation sites built using the Tech Docs Template.

--- a/source/publish/push_repo.md
+++ b/source/publish/push_repo.md
@@ -104,12 +104,11 @@ you deploy your site with GitHub Pages.
 
 ### Add basic authentication
 
-There are many ways to add basic authentication to your documentation site. 
+There are many ways to add basic authentication to your documentation site.
 
-The following instructions apply if you:
+The following instructions apply if you want to deploy your documentation site on the GOV.UK PaaS or another platform using the [Cloud Foundry open source cloud application platform](https://www.cloudfoundry.org/).
 
-- want to deploy your documentation site on the GOV.UK PaaS
-- only have to push your documentation site to the GOV.UK PaaS once, for example if it is a temporary site to review a content change
+This method relies on adding a `Staticfile.auth` file to the `build` folder because building the documentation doesn't automatically add the `Staticfile.auth` file. If you added `Staticfile.auth` once and run the build command again, the file will disappear. You need to add `Staticfile.auth` again to enable basic authentication for the new build.
 
 1. In the command line, navigate to your local documentation repo.
 
@@ -117,9 +116,9 @@ The following instructions apply if you:
 
 1. Create a new `Staticfile.auth` file in the `build` folder.
 
-1. Go to the [Htpasswd Generator](http://www.htaccesstools.com/htpasswd-generator). 
+1. Go to the [Htpasswd Generator](http://www.htaccesstools.com/htpasswd-generator).
 
-1. Complete the __Username__ and __Password__ fields, and select __Create .htpasswd file__. 
+1. Complete the __Username__ and __Password__ fields, and select __Create .htpasswd file__.
 
 1. Copy the generated username and password hash into the `Staticfile.auth` file and save.
 


### PR DESCRIPTION
### Context

Adding basic auth to temporary documentation sites is useful to restrict access e.g. during recruitment.

### Changes proposed in this pull request

Adds content on adding basic auth to your documentation site.

### Guidance to review
