### PR TITLE
Review prerequisites

### DIFF
--- a/source/getting_started/install_macs.md
+++ b/source/getting_started/install_macs.md
@@ -3,7 +3,6 @@
 You must have the following set up on your mac laptop:
 
 - administrator rights on your laptop
-- text editor
 - [Xcode](https://developer.apple.com/xcode/) command line interface tools [external link]
 - [Ruby](https://www.ruby-lang.org/en/) [external link]
 - [Middleman](https://middlemanapp.com/) static site generator [external link]
@@ -13,10 +12,6 @@ You must have the following set up on your mac laptop:
 Email [sd-community@digital.cabinet-office.gov.uk](mailto:sd-community@digital.cabinet-office.gov.uk) to request administrator rights on your laptop.
 
 You must be a Government Digital Service employee to do this.
-
-## Install text editor
-
-You should install a text editor to edit your content.
 
 ## Install Xcode command line interface tools
 

--- a/source/getting_started/install_macs.md
+++ b/source/getting_started/install_macs.md
@@ -8,8 +8,6 @@ You must have the following set up on your mac laptop:
 - [Ruby](https://www.ruby-lang.org/en/) [external link]
 - [Middleman](https://middlemanapp.com/) static site generator [external link]
 
-You must also have a [GitHub account](https://github.com/) [external link] with access to alphagov at `https://github.com/alphagov/paas-tech-docs`.
-
 ## Administrator rights on your laptop
 
 Email [sd-community@digital.cabinet-office.gov.uk](mailto:sd-community@digital.cabinet-office.gov.uk) to request administrator rights on your laptop.


### PR DESCRIPTION
### Context

This is to review the list of requirements for Macs.

The 'Prerequisites' page should say what the prerequisites enable the user to do. 
Some requirements listed are redundant, while others don't necessarily apply for all tasks a user might carry out. One could even argue that you need none of the stuff in the list to contribute to docs if you use the GitHub UI.

### Changes proposed in this pull request

The PR proposes removing 2 redundant requirements.

First, remove:

"You must also have a [GitHub account](https://github.com/) [external link] with access to alphagov at `https://github.com/alphagov/paas-tech-docs`."

The link does not make sense and there is no need for access to alphagov to use and contribute to the TDT. Also users don't even need a GitHub account if they just want to use the TDT.

Second, remove the requirement for a text editor since all laptops come with some form of text editor. If this is more of an on-boarding guide for people at GDS, we should make it clear and suggest getting Atom or some other editor.