### PR TITLE
Remove [external link] labels

### DIFF
--- a/source/getting_started/install_macs.md
+++ b/source/getting_started/install_macs.md
@@ -3,9 +3,9 @@
 You must have the following set up on your mac laptop:
 
 - administrator rights on your laptop
-- [Xcode](https://developer.apple.com/xcode/) command line interface tools [external link]
-- [Ruby](https://www.ruby-lang.org/en/) [external link]
-- [Middleman](https://middlemanapp.com/) static site generator [external link]
+- [Xcode](https://developer.apple.com/xcode/) command line interface tools
+- [Ruby](https://www.ruby-lang.org/en/)
+- [Middleman](https://middlemanapp.com/) static site generator
 
 ## Administrator rights on your laptop
 
@@ -25,16 +25,16 @@ These instructions assume that you are the Managed Software Centre on your Mac.
 
 OR
 
-1. Go to [Apple Developer Downloads](https://developer.apple.com/download/more) [external link].
+1. Go to [Apple Developer Downloads](https://developer.apple.com/download/more).
 1. Search for "xcode".
 1. Select the appropriate __Command Line Tools (macOS x.x) for Xcode x.x__ and download the file.
 1. Install the file.
 
 ## Install Ruby
 
-[Ruby](https://www.ruby-lang.org/en/) [external link] is installed globally. This means that you can run the install command from any location on your local machine rather than from within a specific folder.
+[Ruby](https://www.ruby-lang.org/en/) is installed globally. This means that you can run the install command from any location on your local machine rather than from within a specific folder.
 
-You can install Ruby in multiple ways, for example using [Ruby Version Manager](https://rvm.io/) (RVM) or [rbenv](https://github.com/rbenv/rbenv) [external links]. These instructions assume you are using RVM.
+You can install Ruby in multiple ways, for example using [Ruby Version Manager](https://rvm.io/) (RVM) or [rbenv](https://github.com/rbenv/rbenv). These instructions assume you are using RVM.
 
 1. Run the following in the command line interface to install the ruby version manager:
 
@@ -46,7 +46,7 @@ You can install Ruby in multiple ways, for example using [Ruby Version Manager](
 
 ## Install Middleman
 
-[Middleman](https://middlemanapp.com/) [external link] is installed globally. This means that you can run the install command from any location on your local machine rather than from within a specific folder.
+[Middleman](https://middlemanapp.com/) is installed globally. This means that you can run the install command from any location on your local machine rather than from within a specific folder.
 
 Run the following in the command line interface to install Middleman:
 

--- a/source/introduction/introduction.md
+++ b/source/introduction/introduction.md
@@ -4,7 +4,7 @@
 
 This tool is a template for technical and developer documentation.
 
-It uses the [Middleman static site generator](https://middlemanapp.com/) [external link] to convert markdown files into HTML-based documentation that looks consistent with the GOV.UK and GDS style and format.
+It uses the [Middleman static site generator](https://middlemanapp.com/) to convert markdown files into HTML-based documentation that looks consistent with the GOV.UK and GDS style and format.
 
 It is suitable for multiple styles of documentation, including API documentation.
 

--- a/source/middleman.html.md.erb
+++ b/source/middleman.html.md.erb
@@ -6,7 +6,7 @@ weight: 87
 # Middleman options
 
 The Tech Docs Template is built with
-[Middleman](https://middlemanapp.com/) [external link], so it offers all the same
+[Middleman](https://middlemanapp.com/), so it offers all the same
 functionality. Much of this is not specific to the tool itself.
 
 For example, you can read Middleman's own documentation about:
@@ -14,5 +14,3 @@ For example, you can read Middleman's own documentation about:
 * how to set up [redirects](https://middlemanapp.com/basics/redirects/)
 * the development cycle, and [how to run a local version of your site](https://middlemanapp.com/basics/development-cycle/)
 * how to [build your site](https://middlemanapp.com/basics/build-and-deploy/)
-
-[external links]

--- a/source/publish/push_repo.md
+++ b/source/publish/push_repo.md
@@ -18,7 +18,7 @@ To push your documentation changes to GitHub for the first time, you must:
 
 ### Create local and remote GitHub repos
 
-1. [Create a remote empty repo](https://help.github.com/articles/create-a-repo/) [external link] in your organisation on GitHub.
+1. [Create a remote empty repo](https://help.github.com/articles/create-a-repo/) in your organisation on GitHub.
 
 1. [Create a new local documentation repo](/create_new_project.html#create-a-new-project) if required.
 
@@ -78,7 +78,7 @@ git push -u origin master
 
 You have now created a remote documentation repo on GitHub.
 
-For more information, refer to [Adding an existing project to GitHub](https://help.github.com/articles/adding-an-existing-project-to-github-using-the-command-line/) [external link].
+For more information, refer to [Adding an existing project to GitHub](https://help.github.com/articles/adding-an-existing-project-to-github-using-the-command-line/).
 
 ## Deploy your site
 


### PR DESCRIPTION
### Context

The [content design guidance on links](https://www.gov.uk/guidance/content-design/links) no longer requires `[external link]` labelling of linked text leading outside of the trusted `.gov.uk` domain.

This is great because these `[external link]` labels make the content look messy and unfinished, which is potentially damaging users' trust in the content.

It should still be obvious to the user when they've been sent to a different domain.

### Changes

Remove `[external link]` labels.

The recognisably different branding on the external websites suggests there is no reason documentation users will be confused and believe they're still on the Tech Docs Template documentation website. 