### PR TITLE
Rename "API Reference" to "Add an OpenAPI specification to your documentation"

### DIFF
--- a/source/add_an_openapi_specification.html.md.erb
+++ b/source/add_an_openapi_specification.html.md.erb
@@ -1,0 +1,6 @@
+---
+title: "Add an OpenAPI specification to your documentation"
+weight: 80
+---
+
+<%= partial 'functionality/add_an_openapi_specification' %>

--- a/source/api_ref.html.md.erb
+++ b/source/api_ref.html.md.erb
@@ -1,6 +1,0 @@
----
-title: "API reference"
-weight: 80
----
-
-<%= partial 'functionality/api_reference' %>

--- a/source/functionality/add_an_openapi_specification.md
+++ b/source/functionality/add_an_openapi_specification.md
@@ -1,6 +1,6 @@
-# Enable API reference 
+# Add an OpenAPI specification to your documentation
 
-This feature extracts endpoint information from an Open API v3 yaml file that describes an API.
+This tool can extract endpoint information from an [Open API v3 specification](https://swagger.io/docs/specification/about/) in a YAML file.
 
 ## Amend the tech-docs.yml file
 


### PR DESCRIPTION
### Context

We recently used this template to document an API, and very nearly missed the useful feature which automatically generates good-looking documentation from an OpenAPI spec. It was hidden under the the term "API reference", which is not very explicit.

### Changes proposed in this pull request

Change the menu item "API reference" to "Incorporate an OpenAPI spec", and change the associated page title too.

While we're here, add a link to the swagger.io `/about` page to help those who don't know what OpenAPI is.

### Guidance to review

a) agree/disagree that the existing menu item is a bit obscure
b) consider whether the replacement could be better worded