### PR TITLE
Removed reference to 'internal' use

### DIFF
--- a/source/introduction/introduction.md
+++ b/source/introduction/introduction.md
@@ -18,4 +18,4 @@ This documentation is currently under construction.
 
 ## Who should use this tool
 
-The Tech Docs Template is intended for internal use by the GDS and government community.
+The Tech Docs Template is intended for use by the GDS and government community.


### PR DESCRIPTION
### Context
We state that use is intended for 'internal' use by the GDS and government community. It's unclear what we mean by this, making it potentially confusing.

### Changes proposed in this pull request
Removing reference to 'internal' in the introduction.