### PR TITLE
fix link to middleman-gh-pages

### DIFF
--- a/source/publish/push_repo.md
+++ b/source/publish/push_repo.md
@@ -97,8 +97,7 @@ government services.
 
 With some modification, you can also deploy your site with [GitHub
 Pages](https://pages.github.com/), but we do not support this. To do this, you
-could for example use the [`middleman-gh-pages`]
-tool](https://github.com/edgecase/middleman-gh-pages), which we do not
+could for example use the [`middleman-gh-pages`](https://github.com/edgecase/middleman-gh-pages) tool, which we do not
 support. We also cannot guarantee that all features of the tool will work if
 you deploy your site with GitHub Pages.
 


### PR DESCRIPTION
### Context
 The link in the the github pages section was incorrectly formatted markdown

### Changes proposed in this pull request
adjust link

### Guidance to review
test link works