### PR TITLE
Re-configure header links

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -10,7 +10,6 @@ phase: Beta
 # Links to show on right-hand-side of header
 header_links:
   About: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/communities-of-practice/content/technical-writing
-  Documentation: /
   Support: /support
 
 # Table of contents depth – how many levels to include in the table of contents.

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -9,6 +9,8 @@ phase: Beta
 
 # Links to show on right-hand-side of header
 header_links:
+  Template: https://github.com/alphagov/tech-docs-template
+  Ruby gem: https://github.com/alphagov/tech-docs-gem
   Support: /support
 
 # Table of contents depth – how many levels to include in the table of contents.

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -11,7 +11,7 @@ phase: Beta
 header_links:
   About: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/communities-of-practice/content/technical-writing
   Documentation: /
-  Support: /
+  Support: /support
 
 # Table of contents depth – how many levels to include in the table of contents.
 # If your ToC is too long, reduce this number and we'll only show higher-level

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -9,7 +9,6 @@ phase: Beta
 
 # Links to show on right-hand-side of header
 header_links:
-  About: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/communities-of-practice/content/technical-writing
   Support: /support
 
 # Table of contents depth – how many levels to include in the table of contents.


### PR DESCRIPTION
### Context

The links in the website header are not useful.
'Documentation' and 'Support' don't go anywhere.
'About' goes to a GDS Wiki page which users outside GDS cannot access.

### Changes proposed in this pull request

Remove the links to 'Documentation' and 'About'.

Link 'Support' to the new 'Support' section.

Create new links to go to the template repo and the tehc docs gem repo on GitHub which are more useful.

See commit messages for more details.

Fixes #89 

### Guidance to review

Assess proposal for new header links and propose an alternative if appropriate.
