### PR TITLE
Escape ERB to fix the code block example

### DIFF
--- a/source/amend_project/content/index.html.md.erb
+++ b/source/amend_project/content/index.html.md.erb
@@ -139,5 +139,5 @@ This warning text format is consistent with the [GOV.UK Design System warning te
 Insert the following Ruby code into your content file:
 
 ```ruby
-<%= warning_text('INSERT WARNING TEXT HERE') %>
+<%%= warning_text('INSERT WARNING TEXT HERE') %>
 ```


### PR DESCRIPTION
We need to escape the ERB command to have it rendered as a command in the
code block example. Not escaping the ERB means the command is being
executed, which is not the point of this content.

### Context

ERB in code block examples gets executed rather than being displayes as is.

For example, the code block containing our Middleman helper method

![image](https://user-images.githubusercontent.com/17963330/68487447-021cf680-023b-11ea-9f4c-88df63987fa9.png)

Gets evaluated and displayed as HTML, which defeats the point of that piece of guidance:

![image](https://user-images.githubusercontent.com/17963330/68487498-12cd6c80-023b-11ea-9d68-5a7a9071bffa.png)

### Changes proposed in this pull request

Escape the ERB example using `<%%=` instead of `<%=` to avoid it being executed.

![image](https://user-images.githubusercontent.com/17963330/68487786-a3a44800-023b-11ea-837d-c47034bb50bb.png)

Renders as:

![image](https://user-images.githubusercontent.com/17963330/68487664-63dd6080-023b-11ea-8d6f-cebccf879dae.png)


### How to review

Check the code block example  contains ERB, not HTML.