### PR TITLE
Set up redirects

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -40,3 +40,10 @@ owner_slack_workspace: gds
 
 # Enable GOV.UK crown logo
 show_govuk_logo: false
+
+redirects:
+  page-expiry.html: review_project/page-expiry/index.html
+  search.html: amend_project/configuration/index.html
+  content.html: amend_project/content/index.html
+  create_new_project.html: create_project/create_new_project/index.html
+  single_page.html: create_project/single_page/index.html

--- a/source/create_project/multipage/index.html.md.erb
+++ b/source/create_project/multipage/index.html.md.erb
@@ -11,7 +11,7 @@ You can create a technical documentation site that splits its content across mul
 
 This is suitable for documentation sites that have too much content for the single page format.
 
-You should use the [search feature](search.html#enable-search) with multipage documentation sites.
+You should use the [search feature](/search.html#enable-search) with multipage documentation sites.
 
 ## Basic multipage
 

--- a/source/create_project/single_page/index.html.md.erb
+++ b/source/create_project/single_page/index.html.md.erb
@@ -13,9 +13,9 @@ This is suitable for documentation sites that have do not have a lot of content,
 
 ## Organise content files
 
-1. [Create the content files](create_new_project.html#create-a-new-project) for your documentation site.
+1. [Create the content files](/create_new_project.html#create-a-new-project) for your documentation site.
 
-1. [Amend your content files](content.html#content-examples) to ready them for your documentation site.
+1. [Amend your content files](/content.html#content-examples) to ready them for your documentation site.
 
 1. Save your content files inside your documentation repo in your desired hierarchy.
 
@@ -27,7 +27,7 @@ This is suitable for documentation sites that have do not have a lot of content,
 
 1. Amend the `index.html.md.erb` file.
 
-    You can either [add a `partial` line](single_page.html#add-partial-lines) that references each content file that makes up your overall documentation site, or add the content into the `index.html.md.erb` file directly.
+    You can either [add a `partial` line](/single_page.html#add-partial-lines) that references each content file that makes up your overall documentation site, or add the content into the `index.html.md.erb` file directly.
 
     The .html.md.erb files must not have the same name as the folders that the .html.md.erb files use partials refer to.
 


### PR DESCRIPTION
### Context

Changing the information architecture as part of https://github.com/alphagov/tdt-documentation/pull/97 meant that some links broke.

### Changes proposed in this pull request

The scope of this PR is to redirect broken links so that links to the old pages don't return 404s, but take the user to the right place in the new information architecture.

I'm using the list @36degrees put together in issue https://github.com/alphagov/tdt-documentation/issues/105 to keep track of the work:

|From|To                           |Anchor Text| Redirected to |
|----|-----------------------------|-----------|----|
|https://tdt-documentation.london.cloudapps.digital/review_project/page-expiry/|https://tdt-documentation.london.cloudapps.digital/review_project/page-expiry/not-expired-page.png|           | Unlikely to be linked to |
|https://tdt-documentation.london.cloudapps.digital/create_project/single_page/|https://tdt-documentation.london.cloudapps.digital/create_project/single_page/create_new_project.html|Create the content files| create_project/create_new_project/index.html|
|https://tdt-documentation.london.cloudapps.digital/publish_project/push_repo/|https://tdt-documentation.london.cloudapps.digital/create_new_project.html|Create a new local documentation repo| create_project/create_new_project/index.html|
|https://tdt-documentation.london.cloudapps.digital//publish_project/push_repo/|https://tdt-documentation.london.cloudapps.digital/create_new_project.html|Create a new local documentation repo| create_project/create_new_project/index.html |
|https://tdt-documentation.london.cloudapps.digital/amend_project/configuration/|https://tdt-documentation.london.cloudapps.digital/amend_project/configuration/docs/frontmatter.md|setting old_paths in the frontmatter| This link never existed.|
|https://tdt-documentation.london.cloudapps.digital/create_project/multipage/|https://tdt-documentation.london.cloudapps.digital/create_project/multipage/search.html|search feature| amend_project/configuration/index.html |
|https://tdt-documentation.london.cloudapps.digital/create_project/single_page/|https://tdt-documentation.london.cloudapps.digital/create_project/single_page/single_page.html|add a partial line| create_project/single_page/index.html |
|https://tdt-documentation.london.cloudapps.digital/review_project/page-expiry/|https://tdt-documentation.london.cloudapps.digital/review_project/page-expiry/last-reviewed-only.png|           | Unlikely to be linked to |
|https://tdt-documentation.london.cloudapps.digital/review_project/page-expiry/|https://tdt-documentation.london.cloudapps.digital/review_project/page-expiry/expired-page.png|           | Unlikely to be linked to |
|https://tdt-documentation.london.cloudapps.digital/create_project/single_page/|https://tdt-documentation.london.cloudapps.digital/create_project/single_page/content.html|Amend your content files| amend_project/content/index.html|
|https://tdt-documentation.london.cloudapps.digital/amend_project/configuration/|https://tdt-documentation.london.cloudapps.digital/page-expiry.html|documentation for page expiry| review_project/page-expiry/index.html |
|https://tdt-documentation.london.cloudapps.digital/amend_project/configuration/|https://tdt-documentation.london.cloudapps.digital/page-expiry.html|documentation for page expiry| review_project/page-expiry/index.html |
|https://tdt-documentation.london.cloudapps.digital/amend_project/configuration/|https://tdt-documentation.london.cloudapps.digital/page-expiry.html|documentation for page expiry| review_project/page-expiry/index.html |
|https://tdt-documentation.london.cloudapps.digital/frontmatter.html|https://tdt-documentation.london.cloudapps.digital/page-expiry.html|documentation for page expiry| review_project/page-expiry/index.html |
|https://tdt-documentation.london.cloudapps.digital//amend_project/configuration/|https://tdt-documentation.london.cloudapps.digital/page-expiry.html|documentation for page expiry| review_project/page-expiry/index.html |
|https://tdt-documentation.london.cloudapps.digital//amend_project/configuration/|https://tdt-documentation.london.cloudapps.digital/page-expiry.html|documentation for page expiry| review_project/page-expiry/index.html |
|https://tdt-documentation.london.cloudapps.digital//amend_project/configuration/|https://tdt-documentation.london.cloudapps.digital/page-expiry.html|documentation for page expiry| review_project/page-expiry/index.html |
|https://tdt-documentation.london.cloudapps.digital//frontmatter.html|https://tdt-documentation.london.cloudapps.digital/page-expiry.html|documentation for page expiry| review_project/page-expiry/index.html |
|https://tdt-documentation.london.cloudapps.digital//create_project/single_page/|https://tdt-documentation.london.cloudapps.digital//create_project/single_page/single_page.html|add a partial line| create_project/single_page/index.html|
|https://tdt-documentation.london.cloudapps.digital//amend_project/configuration/|https://tdt-documentation.london.cloudapps.digital//amend_project/configuration/docs/frontmatter.md|setting old_paths in the frontmatter| This link never existed. |
|https://tdt-documentation.london.cloudapps.digital//review_project/page-expiry/|https://tdt-documentation.london.cloudapps.digital//review_project/page-expiry/last-reviewed-only.png|           | Unlikely to be linked to |
|https://tdt-documentation.london.cloudapps.digital//create_project/single_page/|https://tdt-documentation.london.cloudapps.digital//create_project/single_page/content.html|Amend your content files| amend_project/content/index.html |
|https://tdt-documentation.london.cloudapps.digital//review_project/page-expiry/|https://tdt-documentation.london.cloudapps.digital//review_project/page-expiry/expired-page.png|           | Unlikely to be linked to |
|https://tdt-documentation.london.cloudapps.digital//create_project/single_page/|https://tdt-documentation.london.cloudapps.digital//create_project/single_page/create_new_project.html|Create the content files| create_project/create_new_project/index.html |
|https://tdt-documentation.london.cloudapps.digital//review_project/page-expiry/|https://tdt-documentation.london.cloudapps.digital//review_project/page-expiry/not-expired-page.png|           | Unlikely to be linked to |
|https://tdt-documentation.london.cloudapps.digital//create_project/multipage/|https://tdt-documentation.london.cloudapps.digital//create_project/multipage/search.html|search feature| amend_project/configuration/index.html |

`https://tdt-documentation.london.cloudapps.digital/amend_project/configuration/docs/frontmatter.md` never existed as a link - it's always been wrong and it was never picked up because we don't have a link checker in place (yet!). Setting up a link checker is out of scope for this PR. There's a separate PR that adds the link checker and fixes the links: https://github.com/alphagov/tdt-documentation/pull/107 😁 

The broken image links apply when opening the link in a new tab. The images appear correctly in the page.

Closes #105 

### Guidance to review

Check the redirects work as described.