### PR TITLE
Add GOV.UK Frontend docs to publications table

### DIFF
--- a/source/publish_project/current/index.html.md.erb
+++ b/source/publish_project/current/index.html.md.erb
@@ -1,8 +1,8 @@
 ---
 title: "Current published documentation"
 weight: 53
-last_reviewed_on: 2019-10-03
-review_in: 1 day
+last_reviewed_on: 2020-04-21
+review_in: 3 months
 ---
 
 # Current published technical documentation

--- a/source/publish_project/current/index.html.md.erb
+++ b/source/publish_project/current/index.html.md.erb
@@ -7,19 +7,16 @@ review_in: 1 day
 
 # Current published technical documentation
 
-<div style="height:1px;font-size:1px;">&nbsp;</div>
-
-| Organisation        | Title                                    | Location                                                                               | GitHub repo                                                      |
-|---------------------|------------------------------------------|----------------------------------------------------------------------------------------|------------------------------------------------------------------|
-| Ministry of Justice | Cloud platform user guide                | https://user-guide.cloud-platform.service.justice.gov.uk/                              | https://github.com/ministryofjustice/cloud-platform-user-guide   |
-| HMRC                | VAT (MTD) end-to-end service guide       | https://developer.service.hmrc.gov.uk/guides/vat-mtd-end-to-end-service-guide/         | https://github.com/hmrc/vat-service-guide                        |
-| HMRC                | Self Assessment end-to-end service guide | https://developer.service.hmrc.gov.uk/guides/self-assessment-end-to-end-service-guide/ | https://github.com/hmrc/self-assessment-end-to-end-service-guide |
-| GDS                 | GOV.UK Platform as a Service             | https://docs.cloud.service.gov.uk/#gov-uk-platform-as-a-service                        | https://github.com/alphagov/paas-tech-docs                       |
-| GDS                 | GOV.UK Pay                               | https://docs.payments.service.gov.uk/#gov-uk-pay-documentation                         | https://github.com/alphagov/pay-tech-docs                        |
-| GDS                 | GOV.UK Notify                            | https://www.notifications.service.gov.uk/documentation                                 | https://github.com/alphagov/notifications-python-client          |
-| GDS                 | GOV.UK Verify                            | https://www.docs.verify.service.gov.uk/#gov-uk-verify-technical-documentation          | https://github.com/alphagov/verify-tech-docs                     |
-| GDS                 | GDS Way                                  | https://gds-way.cloudapps.digital/                                                     | https://github.com/alphagov/gds-way                              |
-| GDS                 | GDS Reliability Engineering              | https://reliability-engineering.cloudapps.digital/                                     | https://github.com/alphagov/reliability-engineering              |
-| GDS                 | GOV.UK Registers                         | https://docs.registers.service.gov.uk/#gov-uk-registers-technical-documentation        | https://github.com/alphagov/registers-tech-docs                  |
-
-<div style="height:1px;font-size:1px;">&nbsp;</div>
+| Organisation | Documentation | GitHub repo |
+|:---|:---|:---|:---|
+| Ministry of Justice | [Cloud platform user guide](https://user-guide.cloud-platform.service.justice.gov.uk/) | [Cloud platform user guide GitHub repo](https://github.com/ministryofjustice/cloud-platform-user-guide) |
+| HMRC | [VAT (MTD) end-to-end service guide](https://developer.service.hmrc.gov.uk/guides/vat-mtd-end-to-end-service-guide/) | [VAT (MTD) end-to-end service guide GitHub repo](https://github.com/hmrc/vat-service-guide) |
+| HMRC | [Self Assessment end-to-end service guide](https://developer.service.hmrc.gov.uk/guides/self-assessment-end-to-end-service-guide/) | [Self Assessment end-to-end service guide GitHub repo](https://github.com/hmrc/self-assessment-end-to-end-service-guide) |
+| GDS | [GOV.UK Frontend](http://frontend.design-system.service.gov.uk/) | [GOV.UK Frontend GitHub repo](https://github.com/alphagov/govuk-frontend-docs) |
+| GDS | [GOV.UK Notify](https://www.notifications.service.gov.uk/documentation) | [GOV.UK Notify GitHub repo](https://github.com/alphagov/notifications-python-client) |
+| GDS | [GOV.UK Pay](https://docs.payments.service.gov.uk/#gov-uk-pay-documentation) | [GOV.UK Pay GitHub repo](https://github.com/alphagov/pay-tech-docs) |
+| GDS | [GOV.UK Platform as a Service](https://docs.cloud.service.gov.uk/#gov-uk-platform-as-a-service) | [GOV.UK Platform as a Service GitHub repo](https://github.com/alphagov/paas-tech-docs) |
+| GDS | [GDS Reliability Engineering](https://reliability-engineering.cloudapps.digital/) | [GDS Reliability Engineering GitHub repo](https://github.com/alphagov/reliability-engineering) |
+| GDS | [GOV.UK Registers](https://docs.registers.service.gov.uk/#gov-uk-registers-technical-documentation) | [GOV.UK Registers GitHub repo](https://github.com/alphagov/registers-tech-docs) |
+| GDS | [GOV.UK Verify](https://www.docs.verify.service.gov.uk/#gov-uk-verify-technical-documentation) | [GOV.UK Verify GitHub repo](https://github.com/alphagov/verify-tech-docs) |
+| GDS | [GDS Way](https://gds-way.cloudapps.digital/) | [GDS Way GitHub repo](https://github.com/alphagov/gds-way) |


### PR DESCRIPTION
### Context
GOV.UK Frontend documentation is now using the Tech Docs Template at http://frontend.design-system.service.gov.uk/

### Changes proposed in this pull request
- Update the publications table with the GOV.UK Frontend link and repo
- Correct the table markdown
- Add proper links and make the link text accessible
- Fix ordering of the GDS publications so they're alphabetical
- Update review date

### Guidance to review
Please check if all ok.