### PR TITLE
Escape ERB code inside code sample to prevent leaking in to the page

### DIFF
--- a/source/frontmatter.html.md.erb
+++ b/source/frontmatter.html.md.erb
@@ -60,9 +60,9 @@ If you want more control about the layout, use `core` layout. This allows you to
 layout: core
 ---
 
-<% content_for :sidebar do %>
+<%% content_for :sidebar do %>
   You can put anything in the sidebar.
-<% end %>
+<%% end %>
 
 This page has a configurable sidebar that is independent of the content.
 ```


### PR DESCRIPTION
### Context
To customise what's in the side bar you must use a `content_for` block in embedded ruby.  The code sample for that was unescaped, and as a result the code was being executed instead of rendered as text.

Before
<img width="1127" alt="Screenshot 2020-07-16 at 14 33 28" src="https://user-images.githubusercontent.com/1747386/87677736-05756400-c772-11ea-8099-822cb7bd608d.png">

After
<img width="1127" alt="Screenshot 2020-07-16 at 14 33 46" src="https://user-images.githubusercontent.com/1747386/87677752-07d7be00-c772-11ea-91e0-243bd0093518.png">


### Changes proposed in this pull request
Escape some code in a sample

### Guidance to review
Spin it up locally and check that the code is rendered as text instead of being executed. Maybe check I haven't missed any other locations.
