### PR TITLE
Introduce Google Tag Manager configuration support

### DIFF
--- a/source/amend_project/configuration/index.html.md.erb
+++ b/source/amend_project/configuration/index.html.md.erb
@@ -19,6 +19,14 @@ Tracking ID from Google Analytics
 ga_tracking_id: UA-XXXX-Y
 ```
 
+## `gtm_id`
+
+Google Tag Manager
+
+```yaml
+gtm_id: GTM-XXXX
+```
+
 ## `github_repo`
 
 Your repository. Required if [show_contribution_banner](/amend_project/configuration/#show-contribution-banner) is true.


### PR DESCRIPTION
Introduce Google Tag Manager configuration support

### Context
To provide Google Tag Manager support

### Changes proposed in this pull request
Allows a GTM id to be added via `config/tech-docs.yml`. This will then place a GTM Javascript snippet within the `head` and a GTM `noscript` within the `body`

This PR is in conjunction with https://github.com/alphagov/tech-docs-gem/pull/187

### Guidance to review
