### PR TITLE
Add missing frontmatter

### DIFF
--- a/source/configure_project/frontmatter/index.html.md.erb
+++ b/source/configure_project/frontmatter/index.html.md.erb
@@ -173,5 +173,14 @@ title: My beautiful page
 ---
 ```
 
+### description
+
+Description for the page, used by search engines and when shared on social media.
+
+```yaml
+---
+description: One of the best pages on the Internet.
+---
+```
 
 <%= partial "partials/links" %>

--- a/source/configure_project/frontmatter/index.html.md.erb
+++ b/source/configure_project/frontmatter/index.html.md.erb
@@ -56,6 +56,16 @@ weight: 20
 
 You can enable and disable the following optional settings in the page frontmatter.
 
+### description
+
+Sets the description for the page, which will be used in search engine results or on social media.
+
+```yaml
+---
+description: Configuring page settings in the GDS Technical Documentation Template.
+---
+```
+
 ### hide_in_navigation
 
 Set `hide_in_navigation: true` to prevent the page from being rendered in the main left hand navigation.
@@ -153,6 +163,16 @@ parent: shaving-yaks.html
 ---
 ```
 
+### prevent_indexing
+
+Set `prevent_indexing: true` to prevent the page from being indexed by search engines.
+
+```yaml
+---
+prevent_indexing: true
+---
+```
+
 ### source_url
 
 If the contribution banner is turned on, you can override the "View source" link using `source_url`.
@@ -170,16 +190,6 @@ The browser title of the page.
 ```yaml
 ---
 title: My beautiful page
----
-```
-
-### description
-
-Description for the page, used by search engines and when shared on social media.
-
-```yaml
----
-description: One of the best pages on the Internet.
 ---
 ```
 


### PR DESCRIPTION
### Context

Document missing and new frontmatter options.

### Changes proposed in this pull request

- Document existing 'description' frontmatter, used used by search engines (`<meta name="description">`) and when shared on social media (`<meta property="og:description">`)
- Document new `prevent_indexing` frontmatter, which will be introduced in in https://github.com/alphagov/tech-docs-gem/pull/192

### Guidance to review

You can verify how the `description` frontmatter is used [here](https://github.com/alphagov/tech-docs-gem/blob/d077820ab9dec2373fea4761c9f52d0e76cfc46a/lib/govuk_tech_docs/meta_tags.rb#L10-L11).

The ['prevent_indexing` option could previously be set as a site-wide option](https://tdt-documentation.london.cloudapps.digital/configure_project/global_configuration/#prevent-indexing) but https://github.com/alphagov/tech-docs-gem/pull/192 will make it possible to set it at the individual page level using the page frontmatter.