### PR TITLE
Add link to service manual from Google Analytics config section

### DIFF
--- a/source/configure_project/global_configuration/index.html.md.erb
+++ b/source/configure_project/global_configuration/index.html.md.erb
@@ -126,6 +126,8 @@ enable_search: true
 
 Insert the Google Analytics tracking ID to enable Google Analytics.
 
+If you use Google Analytics, you must follow [the guidance on working with cookies](https://www.gov.uk/service-manual/technology/working-with-cookies-and-similar-technologies) in the GOV.UK Service Manual.
+
 Speak to your technical or engineering community to find out how to enable Google Analytics for your documentation and get a tracking ID.
 
 ```yaml


### PR DESCRIPTION
This change makes it clearer that if you use the config setting to enable Google Analytics, you should follow the guidance on working with cookies in the Service Manual.

We should add something similar to documentation change in https://github.com/alphagov/tdt-documentation/pull/126 (which documents the proposed addition of a Google Tag Manager config setting https://github.com/alphagov/tech-docs-gem/pull/187).
