### PR TITLE
Update accessibility statement dates

### DIFF
--- a/source/accessibility/index.html.md.erb
+++ b/source/accessibility/index.html.md.erb
@@ -61,7 +61,7 @@ Some parts of this website are not fully accessible because of [issues caused by
 
 ### What we’re doing to improve accessibility
 
-We plan to fix the issues with the Technical Documentation Template by the end of 2020.
+We plan to fix the issues with the Technical Documentation Template by the end of March 2021.
 
 ### Preparation of this accessibility statement
 
@@ -97,7 +97,7 @@ This Technical Documentation Template is partially compliant with the Web Conten
 
 - The search field does not have a submit button. This fails [WCAG 2.1 success criterion 3.3.2 Labels or Instructions](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html).
 
-We plan to fix the accessibility issues by the end of 2020.
+We plan to fix the accessibility issues by the end of March 2021.
 
 While GDS takes steps to ensure the Technical Documentation Template is as accessible as possible by default, you still need to carry out contextual research. Using the Technical Documentation Template does not mean your service automatically meets level AA of WCAG 2.1.
 


### PR DESCRIPTION
Updated the date for fixing the Tech Docs Template accessibility issues from “end of December 2020” to “end of March 2021”. As a result of resourcing pressures and re-prioritisation this year, it’s taking longer than we hoped to arrange developer and designer resources to fix the accessibility issues.