### PR TITLE
Fix typo in Tech Docs Template content

### DIFF
--- a/source/configure_project/structure_docs/index.html.md.erb
+++ b/source/configure_project/structure_docs/index.html.md.erb
@@ -45,7 +45,7 @@ CONTENT
 
 When you build or preview your documentation site with this `index.html.md.erb`, the site will be a single page site with the following structure:
 
-- Introducution
+- Introduction
 - Who is this documentation for?
 - Set up the client
 


### PR DESCRIPTION
The current version misspells _Introduction_.