### PR TITLE
Clarify Ruby version number and add example of Ruby version number

### DIFF
--- a/source/create_project/get_started/index.html.md.erb
+++ b/source/create_project/get_started/index.html.md.erb
@@ -49,7 +49,7 @@ You can install Ruby in multiple ways, for example using [Ruby Version Manager][
 
 1. Check the [Ruby downloads page][ruby-downloads] for the latest version of Ruby.
 
-1. Run `rvm install ruby-x.x.x` to install the latest version of [Ruby][ruby].
+1. Run `rvm install ruby-x.x.x` to install the latest version of [Ruby][ruby], where `x.x.x` is the Ruby version number. For example, `rvm install ruby-2.6.1`.
 
 ## Install Middleman
 


### PR DESCRIPTION
### Context

A user found the Get Started content needed clarifying around the Ruby version to install.

### Changes proposed in this pull request

Clarify that `x.x.x` is the Ruby version number.

### Guidance to review
