### PR TITLE
Remove tdt docs content from readme file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@
 
 This repository is used to generate the [documentation website for the Tech Docs Template][tdt-docs] and uses the template itself.
 
-The Tech Docs Template is a [middleman template][mmt] that you can use to build technical documentation websites using a GOV.UK style.
-
-To find out more about setting up and managing content for a website using this template, see the [Tech Docs Template documentation](https://tdt-documentation.london.cloudapps.digital/).
-
 ## Publishing changes
 
 Travis CI automatically publishes changes merged into the master branch of this repository.

--- a/README.md
+++ b/README.md
@@ -4,59 +4,22 @@
 
 This repository is used to generate the [documentation website for the Tech Docs Template][tdt-docs] and uses the template itself.
 
-The Tech Docs Template is a [middleman template][mmt] that
-you can use to build technical documentation websites using a GOV.UK style.
+The Tech Docs Template is a [middleman template][mmt] that you can use to build technical documentation websites using a GOV.UK style.
 
-## Before you start
-
-To use the Tech Docs Template you need:
-
-- [Ruby][install-ruby]
-- [Middleman][install-middleman]
-
-## Making changes
-
-To make changes to the documentation for the Tech Docs Template website, edit files in the `source` folder of this repository.
-
-You can add content by editing the `.html.md.erb` files. These files support content in:
-
-- Markdown
-- HTML
-- Ruby
-
-👉 You can use Markdown and HTML to [generate different content types][example-content] and [Ruby partials to manage content][partials].
-
-👉 Learn more about [producing more complex page structures][multipage] for your website.
-
-## Preview your changes locally
-
-To preview your new website locally, navigate to your project folder and run:
-
-```sh
-bundle exec middleman server
-```
-
-👉 See the generated website on `http://localhost:4567` in your browser. Any content changes you make to your website will be updated in real time.
-
-To shut down the Middleman instance running on your machine, use `ctrl+C`.
-
-If you make changes to the `config/tech-docs.yml` configuration file, you need to restart Middleman to see the changes.
+To find out more about setting up and managing content for a website using this template, see the [Tech Docs Template documentation](https://tdt-documentation.london.cloudapps.digital/).
 
 ## Publishing changes
 
 Travis CI automatically publishes changes merged into the master branch of this repository.
 
-## Troubleshooting
-
-Run `bundle exec middleman build --verbose` to get detailed error messages to help with finding the problem.
-
 ## Code of conduct
 
-Please refer to the `alphagov` [code of conduct](https://github.com/alphagov/code-of-conduct).
+Refer to the `alphagov` [code of conduct](https://github.com/alphagov/code-of-conduct).
 
 ## Licence
 
 Unless stated otherwise, the codebase is released under the [MIT License](LICENSE). This covers both the codebase and any sample code in the documentation.
+
 The documentation is [© Crown copyright](http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/) and available under the terms of the [Open Government 3.0 licence](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).
 
 [mmt]: https://middlemanapp.com/advanced/project_templates/


### PR DESCRIPTION
The [tech-docs-template repo README](https://github.com/alphagov/tech-docs-template) no longer has content that duplicates [the TDT documentation](https://tdt-documentation.london.cloudapps.digital/).

This PR does the same for the tdt-documentation repo.

Trello card: https://trello.com/c/m4JOepVJ/153-de-duplicate-tech-docs-repo-readmes