### PR TITLE
Document row level headers

### DIFF
--- a/source/write_docs/content/index.html.md.erb
+++ b/source/write_docs/content/index.html.md.erb
@@ -37,12 +37,21 @@ You should include `<div style="height:1px;font-size:1px;">&nbsp;</div>` before 
 <div style="height:1px;font-size:1px;">&nbsp;</div>
 ```
 
+Add more columns and rows as needed.
+
 You can change the alignment of the text:
 
 - Centre: `|:---:|`
 - Right: `|---:|`
 
-Add more columns and rows as needed.
+You can create row headings by prefixing the content of the cell with `# `:
+
+```bash
+|Column header|Column header|
+|:---|:---|
+|# Row header|content|
+|# Row header|content|
+```
 
 ### Create table using HTML
 


### PR DESCRIPTION
This requires https://github.com/alphagov/tech-docs-gem/pull/214 to be released first - the current version of the tech docs template doesn't support row headers in markdown tables.

Alternatively we could document that you need to use HTML tables to set row level headings.

### Context

Sometimes, tables have row-level headings as well as column level headings.

To be accessible, these need to be marked up as `<th>` tags. Otherwise users of screen readers and other assistive technology may not be able to work out that they're table headings rather than ordinary table cells.

This came up in a recent accessibility report.

### Changes proposed in this pull request

Document how to use row level headers in markdown tables (https://github.com/alphagov/tech-docs-gem/pull/214 needs to be released first).

### Guidance to review

* [x] Review https://github.com/alphagov/tech-docs-gem/pull/214
* [ ] Check the new docs make sense