### PR TITLE
Update table markdown guidance

### DIFF
--- a/source/write_docs/content/index.html.md.erb
+++ b/source/write_docs/content/index.html.md.erb
@@ -22,27 +22,30 @@ Use Markdown when there are no specific formatting requirements.
 
 This example is a left-aligned table.
 
-You should include `<div style="height:1px;font-size:1px;">&nbsp;</div>` before and after each table.
-
 ```bash
-<div style="height:1px;font-size:1px;">&nbsp;</div>
-```
-```bash
-|Column header|Column header|
-|:---|:---|
-|content|content|
-|content|content|
-```
-```bash
-<div style="height:1px;font-size:1px;">&nbsp;</div>
+| Column header | Column header |
+|---------------|---------------|
+| content       | content       |
+| content       | content       |
 ```
 
-You can change the alignment of the text:
+Add more columns and rows as needed.
+
+You can also change the alignment of the text in each column:
 
 - Centre: `|:---:|`
 - Right: `|---:|`
 
-Add more columns and rows as needed.
+If a table has 3 or more columns, you might need to set a [row header](https://www.w3.org/WAI/tutorials/tables/) in addition to the column headers. Setting a row header improves the experience for screen reader users, as it reduces the amount of information they need to remember while navigating the table.
+
+Here is an example where the "city name" cell in each row is marked up as the row header:
+
+```bash
+| City name         | Population | Average age |
+|-------------------|------------|-------------|
+| # Some city       | 38000      | 48          |
+| # Some other city | 41000      | 37          |
+```
 
 ### Create table using HTML
 


### PR DESCRIPTION
This removes the requirement to add a `<div>` above and below tables. This was originally required because omitting them would break the table completely, but this no longer seems to be an issue. The spacing between the table and the surrounding content is now slightly reduced as a result, but this should be fixed with CSS in the tech docs gem, rather than with non-semantic content.

This commit also documents new accessibility guidance whereby tables with 3 or more columns need a row header, introduced in https://github.com/alphagov/tech-docs-gem/pull/214.

While I'm here, I've updated the markdown example to use padded cells for horizontal alignment, which is good practice if there is room to do so. I've also omitted the `|:---|` left-alignment instruction, since cells are left-aligned by default. Most markdown table examples you'll come across in the wild use the default `|---|` separator.

### Context


### Changes proposed in this pull request


### Guidance to review
