### PR TITLE
Update accessibility statement to say not fully compliant

### DIFF
--- a/source/accessibility/index.html.md.erb
+++ b/source/accessibility/index.html.md.erb
@@ -53,7 +53,7 @@ This website is partially compliant with the [Web Content Accessibility Guidelin
 
 ### Preparation of this accessibility statement
 
-This statement was prepared on 2 September 2020. It was last reviewed on 18 June 2021.
+This statement was prepared on 2 September 2020. It was last reviewed on 23 June 2021.
 
 This website was last tested in March 2021.
 
@@ -63,9 +63,9 @@ This [Technical Documentation Template](https://github.com/alphagov/tech-docs-te
 
 DAC tested the [GovWifi technical documentation](https://docs.wifi.service.gov.uk/), which uses this Technical Documentation Template.
 
-This Technical Documentation Template is partially compliant with the Web Content Accessibility Guidelines version 2.1 AA standard, due to the non-compliances listed below.
+This Technical Documentation Template is partially compliant with the Web Content Accessibility Guidelines version 2.1 AA standard due to the non-compliances listed below.
 
-- In some circumstances, the main page heading is automatically focused when the page loads. This means keyboard-only users may miss the navigation elements. This fails [WCAG 2.1 success criterion 2.4.3 - Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html).
+- In some circumstances, the main page heading is automatically in focus when the page loads. This means keyboard-only users may miss the navigation elements. This fails [WCAG 2.1 success criterion 2.4.3 - Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html).
 - The navigation elements are not marked up semantically as hierarchical headings, which means moving through the navigation using a screen reader may be more difficult. This fails [WCAG 2.1 success criterion 1.3.1 - Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html).
 - There are sections of content with show / hide functionality. The `aria-expanded` attribute is not implemented correctly, so users may miss that menu items are expandable. This fails [WCAG 2.1 success criterion 4.1.2 - Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html).
 - When a user searches, the search results dialogue hides the main page region from assistive technology. This fails [WCAG 2.1 success criterion 3.2.2 - On Input](https://www.w3.org/WAI/WCAG21/Understanding/on-input.html) and [WCAG 2.1 success criterion 2.4.3 - Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html).

--- a/source/accessibility/index.html.md.erb
+++ b/source/accessibility/index.html.md.erb
@@ -70,6 +70,8 @@ This Technical Documentation Template is partially compliant with the Web Conten
 - There are sections of content with show / hide functionality. The `aria-expanded` attribute is not implemented correctly, so users may miss that menu items are expandable. This fails [WCAG 2.1 success criterion 4.1.2 - Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html).
 - The main page region is hidden from assistive technology when the search results dialog is triggered. This fails [WCAG 2.1 success criterion 3.2.2 - On Input](https://www.w3.org/WAI/WCAG21/Understanding/on-input.html) and [WCAG 2.1 success criterion 2.4.3 - Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html).
 
+We plan to fix these issues by 31 July 2021.
+
 While GDS takes steps to ensure the Technical Documentation Template is as accessible as possible by default, you still need to carry out contextual research.
 
 You’ll still need to make sure your documentation as a whole meets accessibility requirements. You must research your documentation content to ensure that it’s in context.

--- a/source/accessibility/index.html.md.erb
+++ b/source/accessibility/index.html.md.erb
@@ -27,7 +27,9 @@ We’ve also made the website text as simple as possible to understand.
 
 ### How accessible this website is
 
-This website is fully compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard.
+We know some parts of this website are not fully accessible because of [issues caused by our Technical Documentation Template](#using-the-technical-documentation-template-for-your-own-documentation).
+
+We’re committed to making this website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
 
 #### Feedback and contact information
 
@@ -47,21 +49,28 @@ The Equality and Human Rights Commission (EHRC) is responsible for enforcing the
 
 ##### Compliance status
 
-This website is fully compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard.
+This website is partially compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard.
 
 ### Preparation of this accessibility statement
 
-This statement was prepared on 2 September 2020. It was last reviewed on 29 March 2021.
+This statement was prepared on 2 September 2020. It was last reviewed on 18 June 2021.
 
-This website was last tested in March 2021.
+This website was last tested in April 2021.
 
 ## Using the Technical Documentation Template for your own documentation
 
-This [Technical Documentation Template](https://github.com/alphagov/tech-docs-template) was last tested in March 2021.
+This [Technical Documentation Template](https://github.com/alphagov/tech-docs-template) was last tested in April 2021. The test was carried out by the [Digital Accessibility Centre (DAC)](https://digitalaccessibilitycentre.org/).
 
-The Technical Documentation Template is fully compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard.
+DAC tested the [GovWifi website](https://admin.wifi.service.gov.uk/users/sign_in) and the [GovWifi technical documentation](https://docs.wifi.service.gov.uk/).
 
-While GDS takes steps to ensure the Technical Documentation Template is as accessible as possible by default, you still need to carry out contextual research. Using the Technical Documentation Template does not mean your service automatically meets level AA of WCAG 2.1.
+This Technical Documentation Template is partially compliant with the Web Content Accessibility Guidelines version 2.1 AA standard, due to the non-compliances listed below:
+
+- On page load, the main page heading in the content is automatically focused. Keyboard-only users expect the focus to be at the top of the page and then move through the navigation elements. Keyboard-only users may therefore miss the navigation elements which would be confusing. This fails [WCAG 2.1 success criterion 2.4.3 - Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html).
+- The navigation elements are not marked-up as hierarchical headings. As screen reader users rely on correct semantic mark-up to determine relationships within the page, this makes navigating a page using a screen reader more difficult. This fails [WCAG 2.1 success criterion 1.3.1 - Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html).
+- There are sections of content with show / hide functionality. The `aria-expanded` attribute is not implemented correctly, so users may miss that menu items are expandable. This fails [WCAG 2.1 success criterion 4.1.2 - Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html).
+- The main page region is hidden from assistive technology when the search results dialog is triggered. This fails [WCAG 2.1 success criterion 3.2.2 - On Input](https://www.w3.org/WAI/WCAG21/Understanding/on-input.html) and [WCAG 2.1 success criterion 2.4.3 - Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html).
+
+While GDS takes steps to ensure the Technical Documentation Template is as accessible as possible by default, you still need to carry out contextual research.
 
 You’ll still need to make sure your documentation as a whole meets accessibility requirements. You must research your documentation content to ensure that it’s in context.
 

--- a/source/accessibility/index.html.md.erb
+++ b/source/accessibility/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Accessibility statement for Technical Documentation Template and documentation
-last_reviewed_on: 2021-03-29
+last_reviewed_on: 2021-06-23
 review_in: 6 months
 hide_in_navigation: true
 ---
@@ -55,20 +55,20 @@ This website is partially compliant with the [Web Content Accessibility Guidelin
 
 This statement was prepared on 2 September 2020. It was last reviewed on 18 June 2021.
 
-This website was last tested in April 2021.
+This website was last tested in March 2021.
 
 ## Using the Technical Documentation Template for your own documentation
 
 This [Technical Documentation Template](https://github.com/alphagov/tech-docs-template) was last tested in April 2021. The test was carried out by the [Digital Accessibility Centre (DAC)](https://digitalaccessibilitycentre.org/).
 
-DAC tested the [GovWifi website](https://admin.wifi.service.gov.uk/users/sign_in) and the [GovWifi technical documentation](https://docs.wifi.service.gov.uk/).
+DAC tested the [GovWifi technical documentation](https://docs.wifi.service.gov.uk/), which uses this Technical Documentation Template.
 
-This Technical Documentation Template is partially compliant with the Web Content Accessibility Guidelines version 2.1 AA standard, due to the non-compliances listed below:
+This Technical Documentation Template is partially compliant with the Web Content Accessibility Guidelines version 2.1 AA standard, due to the non-compliances listed below.
 
-- On page load, the main page heading in the content is automatically focused. Keyboard-only users expect the focus to be at the top of the page and then move through the navigation elements. Keyboard-only users may therefore miss the navigation elements which would be confusing. This fails [WCAG 2.1 success criterion 2.4.3 - Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html).
-- The navigation elements are not marked-up as hierarchical headings. As screen reader users rely on correct semantic mark-up to determine relationships within the page, this makes navigating a page using a screen reader more difficult. This fails [WCAG 2.1 success criterion 1.3.1 - Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html).
+- In some circumstances, the main page heading is automatically focused when the page loads. This means keyboard-only users may miss the navigation elements. This fails [WCAG 2.1 success criterion 2.4.3 - Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html).
+- The navigation elements are not marked up semantically as hierarchical headings, which means moving through the navigation using a screen reader may be more difficult. This fails [WCAG 2.1 success criterion 1.3.1 - Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html).
 - There are sections of content with show / hide functionality. The `aria-expanded` attribute is not implemented correctly, so users may miss that menu items are expandable. This fails [WCAG 2.1 success criterion 4.1.2 - Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html).
-- The main page region is hidden from assistive technology when the search results dialog is triggered. This fails [WCAG 2.1 success criterion 3.2.2 - On Input](https://www.w3.org/WAI/WCAG21/Understanding/on-input.html) and [WCAG 2.1 success criterion 2.4.3 - Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html).
+- When a user searches, the search results dialogue hides the main page region from assistive technology. This fails [WCAG 2.1 success criterion 3.2.2 - On Input](https://www.w3.org/WAI/WCAG21/Understanding/on-input.html) and [WCAG 2.1 success criterion 2.4.3 - Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html).
 
 We plan to fix these issues by 31 July 2021.
 


### PR DESCRIPTION
### Context

There are some new accessibility issues with the Tech Docs Template, reported in a recent DAC audit arranged by the GovWifi team. 

The issues are the following.

- IOn page load, the main page heading in the content is automatically focused. Keyboard-only users expect the focus to be at the top of the page and then move through the navigation elements. Keyboard-only users may therefore miss the navigation elements which would be confusing. This fails [WCAG 2.1 success criterion 2.4.3 - Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html).
- The navigation elements are not marked-up as hierarchical headings. As screen reader users rely on correct semantic mark-up to determine relationships within the page, this makes navigating a page using a screen reader more difficult. This fails [WCAG 2.1 success criterion 1.3.1 - Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html).
- There are sections of content with show / hide functionality. The `aria-expanded` attribute is not implemented correctly, so users may miss that menu items are expandable. This fails [WCAG 2.1 success criterion 4.1.2 - Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html).
- The main page region is hidden from assistive technology when the search results dialog is triggered. This fails [WCAG 2.1 success criterion 3.2.2 - On Input](https://www.w3.org/WAI/WCAG21/Understanding/on-input.html) and [WCAG 2.1 success criterion 2.4.3 - Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html).

### Changes proposed in this pull request

Update accessibility statement to say that tech doc template is not fully compliant and what the issues are.

### Guidance to review
