### PR TITLE
Update docs owner Slack channel

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -32,7 +32,7 @@ github_repo: alphagov/tdt-documentation
 enable_search: true
 
 # Ownership for page reviews
-default_owner_slack: '#tech-writers'
+default_owner_slack: '#gds-technical-writing'
 owner_slack_workspace: gds
 
 redirects:


### PR DESCRIPTION
### Changes proposed in this pull request
The link to the docs owners in the review boxes is incorrect because the Slack channel doesn't exist anymore. Updated to the correct Slack channel.