### PR TITLE
Add contribution documentation

### DIFF
--- a/source/support/index.html.md.erb
+++ b/source/support/index.html.md.erb
@@ -15,12 +15,30 @@ Report any problems or issues by:
 - posting in the [tech docs format][slack-tech-docs-format] Slack channel
 - opening an issue on the [tech-docs-template repo][template-issues]
 
-## GitHub repos
+## Contribute
 
-The repos are:
+We welcome contributions to the Technical Documentation Template.
 
-- the [tech-docs-template]
-- the [tech-docs-gem]
+You can create an issue or pull request in the following GitHub repos:
+
+- [alphagov/tech-docs-gem][tech-docs-gem]
+- [alphagov/tech-docs-template][tech-docs-template]
+- [alphagov/tdt-documentation](https://github.com/alphagov/tdt-documentation) - for this documentation
+
+If you're part of the [alphagov GitHub organisation](https://github.com/alphagov) you should have write access to the repos. If you do not have access, ask a GitHub admin or on the [#tech-docs-format Slack channel](https://app.slack.com/client/T8GT9416G/CADK8N58B).
+
+Before you create a pull request, you should:
+
+- check the repo to see if someone has already raised a similar issue or pull request
+- test your contribution using [unit tests](https://github.com/alphagov/tech-docs-gem/tree/master/spec/govuk_tech_docs), [JavaScript tests](https://github.com/alphagov/tech-docs-gem/tree/master/spec/javascripts) and [integration tests](https://github.com/alphagov/tech-docs-gem/tree/master/spec/features)
+- document the change in this documentation
+- add a description of the change to the repo changelog - unless your change only refactors code
+
+The Central Digital and Data Office (CDDO) technical writing team will review your proposal at their next triage session, then do one of the following:
+
+- accept your proposal but ask for changes before it's prioritised for publication
+- accept your proposal and find someone to work with you to publish the changes
+- not accept your proposal and explain why
 
 ## Projects that use the template
 

--- a/source/support/index.html.md.erb
+++ b/source/support/index.html.md.erb
@@ -25,16 +25,16 @@ You can create an issue or pull request in the following GitHub repos:
 - [alphagov/tech-docs-template][tech-docs-template]
 - [alphagov/tdt-documentation](https://github.com/alphagov/tdt-documentation) - for this documentation
 
-If you're part of the [alphagov GitHub organisation](https://github.com/alphagov) you should have write access to the repos. If you do not have access, ask a GitHub admin or on the [#tech-docs-format Slack channel](https://app.slack.com/client/T8GT9416G/CADK8N58B).
+You should check and document your pull request before you submit it.
 
-Before you create a pull request, you should:
+1. Check the repo to see if someone has already raised a similar pull request or issue.
+2. Test your contribution using [unit tests](https://github.com/alphagov/tech-docs-gem/tree/master/spec/govuk_tech_docs), [JavaScript tests](https://github.com/alphagov/tech-docs-gem/tree/master/spec/javascripts) and [integration tests](https://github.com/alphagov/tech-docs-gem/tree/master/spec/features).
+3. Document the change in this documentation.
+4. Add a description of the change to the repo changelog if your pull request changes how the Technical Documentation Template behaves.
 
-- check the repo to see if someone has already raised a similar issue or pull request
-- test your contribution using [unit tests](https://github.com/alphagov/tech-docs-gem/tree/master/spec/govuk_tech_docs), [JavaScript tests](https://github.com/alphagov/tech-docs-gem/tree/master/spec/javascripts) and [integration tests](https://github.com/alphagov/tech-docs-gem/tree/master/spec/features)
-- document the change in this documentation
-- add a description of the change to the repo changelog - unless your change only refactors code
+The Central Digital and Data Office (CDDO) technical writing team will review your proposal at their next fortnightly triage session.
 
-The Central Digital and Data Office (CDDO) technical writing team will review your proposal at their next triage session, then do one of the following:
+The team will then do one of the following:
 
 - accept your proposal but ask for changes before it's prioritised for publication
 - accept your proposal and find someone to work with you to publish the changes


### PR DESCRIPTION
### Context
We're introducing a new process for Tech Docs Template PRs.

### Changes proposed in this pull request
Add a 'Contributions' section to the Support page that explains the new process. It borrows content from https://github.com/alphagov/tech-docs-gem/blob/master/CONTRIBUTING.md (and we'll update that page to link to this new content).

### Guidance to review
This has been 2i'd - just needs approval to merge.