### PR TITLE
Use Node.js version 14.x.x for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 cache: bundler
 script: bundle exec middleman build
+before_install:
+  - nvm install 14
 deploy:
   provider: cloudfoundry
   api: https://api.london.cloud.service.gov.uk


### PR DESCRIPTION
Travis CI is currently defaulting to using Node.js v8.x.x because the Travis config file does not specify to use Node at all.

However a version of Node greater than 10 is needed for this repo, because the tech-docs-gem uses it.

This commit uses nvm to make sure that the version of Node used for tests is in the current long term support (LTS) series.