### PR TITLE
Add docs about colon

### DIFF
--- a/source/configure_project/global_configuration/index.html.md.erb
+++ b/source/configure_project/global_configuration/index.html.md.erb
@@ -54,6 +54,12 @@ github_repo: alphagov/YOUR_REPO
 
 <%= warning_text('All of these settings are optional. However, you should enable or disable settings to increase the usability of your documentation or because of best practice.') %>
 
+If you put a colon in the value that is not part of a URL, you must wrap the value in quotes. For example:
+
+```
+description: "GDS: My amazing documentation"
+```
+
 If you are not sure which settings to enable or disable, [contact the Government Digital Service (GDS) technical writing team][contact-email].
 
 See the [Platfom as a Service (PaaS) tech docs config file][global-config-example] for an example `tech-docs.yml` file.

--- a/source/configure_project/global_configuration/index.html.md.erb
+++ b/source/configure_project/global_configuration/index.html.md.erb
@@ -54,7 +54,7 @@ github_repo: alphagov/YOUR_REPO
 
 <%= warning_text('All of these settings are optional. However, you should enable or disable settings to increase the usability of your documentation or because of best practice.') %>
 
-If you put a colon in the value that is not part of a URL, you must wrap the value in quotes. For example:
+You must wrap a value in quotes if it contains a colon, unless the value is a URL. For example:
 
 ```
 description: "GDS: My amazing documentation"


### PR DESCRIPTION
## What’s changed

<!-- What are you trying to do? Is this something that changes how the Tech Docs Template behaves, or is it fixing a bug? 🐛 -->

Add documentation on having a colon in a value in the `config/tech-docs.yml` file, and how you need to wrap the value in quotes.

## Identifying a user need

Technical writer in HMRC needed guidance on this on 2021/10/19.
