### PR TITLE
An improved link for deploying using GitHub Pages

### DIFF
--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -22,7 +22,7 @@
 [GDS Web Help Desk]: https://gdshelpdesk.digital.cabinet-office.gov.uk/helpdesk/WebObjects/Helpdesk.woa
 [github_repo]: /configure_project/global_configuration/#github-repo
 [gh-pages]: https://pages.github.com
-[gh-pages-example]: https://github.com/ministryofjustice/cloud-platform
+[gh-pages-example]: https://github.com/ministryofjustice/cloud-platform-user-guide
 [global-config]: /configure_project/global_configuration/#configure-your-documentation-site
 [global-config-example]: https://github.com/alphagov/paas-tech-docs/blob/master/config/tech-docs.yml
 [Google Site Verification code]: https://support.google.com/webmasters/answer/35179?hl=en


### PR DESCRIPTION
The existing link was to MOJ Cloud Platforms' main repo, rather than the documentation repo. This new link is to the latter. It has details to how MOJ Cloud Platforms deploy their TDT site using a GitHub Action, running a docker container that MOJ put together, to publish to GitHub Pages.
