### PR TITLE
Fix deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,4 +36,4 @@ jobs:
           cf_space: 'sandbox'
           cf_username: ${{ secrets.CF_USER }}
           cf_password: ${{ secrets.CF_PASSWORD }}
-          command: cf push -f manifest.yml --strategy rolling
+          command: push -f manifest.yml --strategy rolling


### PR DESCRIPTION
Remove superflous `cf` that was causing deploys to fail with `'cf' is not a registered command`. See https://github.com/alphagov/tdt-documentation/runs/3965751544?check_suite_focus=true for an example.