### PR TITLE
Fix Ruby version in install docs

### DIFF
--- a/source/create_project/get_started/index.html.md.erb
+++ b/source/create_project/get_started/index.html.md.erb
@@ -39,9 +39,9 @@ You can install Ruby anywhere on your computer, using [Ruby Version Manager][rvm
     \curl -sSL https://get.rvm.io | bash -s stable --ruby
     ```
 
-2. Go to the [Ruby downloads page][ruby-downloads] and get the version number of the most recent stable release.
+2. Go to the [Ruby downloads page][ruby-downloads] and get the version number of the most recent Ruby 2.7.x release.
 
-3. Run `rvm install ruby-x.x.x`, where `x.x.x` is the version number. For example, `rvm install ruby-3.0.1`.
+3. Run `rvm install ruby-x.x.x`, where `x.x.x` is the version number. For example, `rvm install ruby-2.7.7`.
 
 You can also install Ruby using other tools such as [rbenv].
 


### PR DESCRIPTION
Fixes https://github.com/alphagov/tdt-documentation/issues/182

The [Get started](https://tdt-documentation.london.cloudapps.digital/create_project/get_started/#install-node-js) page says users should install the most recent stable release of Ruby. But the TDT has only been tested up to 2.7.x, so users should install that instead.

As a result, we've seen people get errors when they try to install the TDT using later versions of Ruby.

This PR updates the install documentation.