### PR TITLE
Rename default branch to 'main'

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 concurrency: production

--- a/README.md
+++ b/README.md
@@ -16,14 +16,4 @@ Unless stated otherwise, the codebase is released under the [MIT License](LICENS
 
 The documentation is [© Crown copyright](http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/) and available under the terms of the [Open Government 3.0 licence](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).
 
-[mmt]: https://middlemanapp.com/advanced/project_templates/
 [tdt-docs]: https://tdt-documentation.london.cloudapps.digital
-
-[config]: https://tdt-documentation.london.cloudapps.digital/configuration-options.html#configuration-options
-[frontmatter]: https://tdt-documentation.london.cloudapps.digital/frontmatter.html#frontmatter
-[multipage]: https://tdt-documentation.london.cloudapps.digital/multipage.html#build-a-multipage-site
-[example-content]: https://tdt-documentation.london.cloudapps.digital/content.html#content-examples
-[partials]: https://tdt-documentation.london.cloudapps.digital/single_page.html#add-partial-lines
-[contribute]: https://github.com/alphagov/tech-docs-gem/blob/master/CONTRIBUTING.md
-[install-ruby]: https://tdt-documentation.london.cloudapps.digital/create_project/setup_local/#install-ruby
-[install-middleman]: https://tdt-documentation.london.cloudapps.digital/create_project/setup_local/#install-middleman

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository is used to generate the [documentation website for the Tech Docs
 
 ## Publishing changes
 
-GitHub Actions automatically publishes changes merged into the master branch of this repository.
+GitHub Actions automatically publishes changes merged into the main branch of this repository.
 
 ## Code of conduct
 

--- a/source/configure_project/global_configuration/index.html.md.erb
+++ b/source/configure_project/global_configuration/index.html.md.erb
@@ -50,6 +50,7 @@ prevent_indexing: false
 
 show_contribution_banner: true
 github_repo: alphagov/YOUR_REPO
+github_branch: main
 ```
 
 <%= warning_text('All of these settings are optional. However, you should enable or disable settings to increase the usability of your documentation or because of best practice.') %>
@@ -190,6 +191,16 @@ Your documentation project's GitHub repository. You must enable this if you have
 github_repo: alphagov/example-repo
 ```
 
+### github_branch
+
+Your project's GitHub default branch name. You can change this if your default branch is not named main.
+
+```yaml
+github_branch: source
+```
+
+Note: When creating a project using the template this is set to "main", but if this setting is not present the default is currently "master". This will change in a future major release.
+
 ## Additional settings
 
 You can enable and disable the following additional settings in the `tech-docs.yml` file.
@@ -217,14 +228,6 @@ The full service name. Include "GOV.UK" if appropriate.
 
 ```yaml
 full_service_name: "GOV.UK Pay"
-```
-
-### github_branch
-
-Your project's GitHub master branch name. You can use this if your default branch is not named master.
-
-```yaml
-github_branch: source
 ```
 
 ### google_site_verification

--- a/source/partials/_links.erb
+++ b/source/partials/_links.erb
@@ -24,7 +24,7 @@
 [gh-pages]: https://pages.github.com
 [gh-pages-example]: https://github.com/ministryofjustice/cloud-platform-user-guide
 [global-config]: /configure_project/global_configuration/#configure-your-documentation-site
-[global-config-example]: https://github.com/alphagov/paas-tech-docs/blob/master/config/tech-docs.yml
+[global-config-example]: https://github.com/alphagov/paas-tech-docs/blob/main/config/tech-docs.yml
 [Google Site Verification code]: https://support.google.com/webmasters/answer/35179?hl=en
 
 [Htpasswd Generator]: http://www.htaccesstools.com/htpasswd-generator
@@ -38,7 +38,7 @@
 [node]: https://nodejs.org/en/
 
 [old-paths]: /configure_project/frontmatter/#old-paths
-[openapi3-spec]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md
+[openapi3-spec]: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md
 [openapi3]: /write_docs/add_openapi_spec/#convert-an-openapi-specification-into-documentation
 
 [paas]: https://www.cloud.service.gov.uk

--- a/source/support/index.html.md.erb
+++ b/source/support/index.html.md.erb
@@ -28,7 +28,7 @@ You can create an issue or pull request in the following GitHub repos:
 You should check and document your pull request before you submit it.
 
 1. Check the repo to see if someone has already raised a similar pull request or issue.
-2. Test your contribution using [unit tests](https://github.com/alphagov/tech-docs-gem/tree/master/spec/govuk_tech_docs), [JavaScript tests](https://github.com/alphagov/tech-docs-gem/tree/master/spec/javascripts) and [integration tests](https://github.com/alphagov/tech-docs-gem/tree/master/spec/features).
+2. Test your contribution using [unit tests](https://github.com/alphagov/tech-docs-gem/tree/main/spec/govuk_tech_docs), [JavaScript tests](https://github.com/alphagov/tech-docs-gem/tree/main/spec/javascripts) and [integration tests](https://github.com/alphagov/tech-docs-gem/tree/main/spec/features).
 3. Document the change in this documentation.
 4. Add a description of the change to the repo changelog if your pull request changes how the Technical Documentation Template behaves.
 

--- a/source/write_docs/add_openapi_spec/index.html.md.erb
+++ b/source/write_docs/add_openapi_spec/index.html.md.erb
@@ -33,7 +33,7 @@ Your OpenAPI file must be both:
 For `api_path` you can also use:
 
 - a relative path, for example `./openapi/openapi.yaml`
-- an external file, for example `https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore.yaml`
+- an external file, for example `https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.yaml`
 
 ## Convert a specific endpoint
 


### PR DESCRIPTION
We're trying to phase out use of the word 'master' as the default default branch name, along with the rest of the software engineering community [[1]].

This PR updates the docs, as we're updating the template in PR alphagov/tech-docs-template#228, and adds a note about changing the default in a future release of the gem (see https://github.com/alphagov/tech-docs-gem/blob/d3a1545158c5f9c78caafcbbbd7ddd097fdeedcb/lib/govuk_tech_docs/contribution_banner.rb#L42).

We also need to update some links and the deploy script for this repo.

[1]: github.com/renaming