### PR TITLE
Replace references to CDDO technical writing group with tdt working group

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 Please fill in the sections below.
 
-After you submit your issue, the technical writing team from the Central Digital and Data Office (CDDO) will discuss and prioritise it at our fortnightly triage meeting. We’ll then let you know if and when we’ll move it forward.
+After you submit your issue, the tech docs template working group will discuss and prioritise it at our fortnightly triage meeting. We’ll then let you know if and when we’ll move it forward.
 -->
 
 ## What should change

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 Please fill in the sections below.
 
-After you submit your issue, the tech docs template working group will discuss and prioritise it at our fortnightly triage meeting. We’ll then let you know if and when we’ll move it forward.
+After you submit your issue, the Tech Docs Template working group will discuss and prioritise it at our fortnightly triage meeting. We’ll then let you know if and when we’ll move it forward.
 -->
 
 ## What should change

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 ## Please fill in the sections below
 
-After you submit your pull request, the technical writing team from the Central Digital and Data Office (CDDO) will discuss and prioritise it at our fortnightly triage meeting. We’ll then let you know if and when we’ll move it forward.
+After you submit your pull request, the tech docs template working group will discuss and prioritise it at our fortnightly triage meeting. We’ll then let you know if and when we’ll move it forward.
 -->
 
 ## What’s changed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 ## Please fill in the sections below
 
-After you submit your pull request, the tech docs template working group will discuss and prioritise it at our fortnightly triage meeting. We’ll then let you know if and when we’ll move it forward.
+After you submit your pull request, the Tech Docs Template working group will discuss and prioritise it at our fortnightly triage meeting. We’ll then let you know if and when we’ll move it forward.
 -->
 
 ## What’s changed

--- a/source/support/index.html.md.erb
+++ b/source/support/index.html.md.erb
@@ -32,7 +32,7 @@ You should check and document your pull request before you submit it.
 3. Document the change in this documentation.
 4. Add a description of the change to the repo changelog if your pull request changes how the Technical Documentation Template behaves.
 
-The tech docs template working group will review your proposal at their next fortnightly triage session.
+The Tech Docs Template working group will review your proposal at their next fortnightly triage session.
 
 The team will then do one of the following:
 

--- a/source/support/index.html.md.erb
+++ b/source/support/index.html.md.erb
@@ -32,7 +32,7 @@ You should check and document your pull request before you submit it.
 3. Document the change in this documentation.
 4. Add a description of the change to the repo changelog if your pull request changes how the Technical Documentation Template behaves.
 
-The Central Digital and Data Office (CDDO) technical writing team will review your proposal at their next fortnightly triage session.
+The tech docs template working group will review your proposal at their next fortnightly triage session.
 
 The team will then do one of the following:
 


### PR DESCRIPTION
<!--
## Please fill in the sections below

After you submit your pull request, the tech docs template working group will discuss and prioritise it at our fortnightly triage meeting. We’ll then let you know if and when we’ll move it forward.
-->

## What’s changed


<!-- What are you trying to do? Is this something that changes how the Tech Docs Template behaves, or is it fixing a bug? -->

Tech docs template is now managed by the working group, update references to CDDO technical writing team (which no longer exists).

## Identifying a user need

<!-- Do you have evidence that this meets the needs of users? Let us know about any user research or testing you’ve done. -->

Closes #189.