### PR TITLE
Remove references to PaaS

### DIFF
--- a/source/publish_project/deploy/index.html.md.erb
+++ b/source/publish_project/deploy/index.html.md.erb
@@ -11,10 +11,6 @@ The Tech Docs Template is built on Middleman, which is a static
 site generator. You can therefore deploy your site anywhere that supports
 static sites.
 
-## Use the GOV.UK PaaS
-
-We recommend that government services use the [GOV.UK PaaS][paas] to deploy documentation sites built with the Tech Docs Template. This is also free of charge for government services.
-
 ## GitHub Pages
 
 With some modification, you can also deploy your site with [GitHub Pages][gh-pages], but we do not support this. To do this, you could for example use the [`middleman-gh-pages` tool][middleman-gh-pages], which we do not support.
@@ -23,15 +19,11 @@ We also cannot guarantee that all features of the template will work if you depl
 
 The [Ministry of Justice cloud platform documentation][gh-pages-example] uses GitHub Pages.
 
-## Continuous integration
-
-The GOV.UK PaaS documentation explains how to set up continuous integration (CI) with [Travis and Jenkins][paas-docs-ci]. We recommend this method for documentation sites built using the Tech Docs Template.
-
 ## Add basic authentication
 
 There are many ways to add basic authentication to your documentation site.
 
-The following instructions apply if you want to deploy your documentation site on the GOV.UK PaaS or another platform using the [Cloud Foundry open source cloud application platform][cf].
+The following instructions apply if you want to deploy your documentation site on any platform using the [Cloud Foundry open source cloud application platform][cf].
 
 This method relies on adding a `Staticfile.auth` file to the `build` folder because building the documentation doesn't automatically add the `Staticfile.auth` file. If you added `Staticfile.auth` once and run the build command again, the file will disappear. You need to add `Staticfile.auth` again to enable basic authentication for the new build.
 


### PR DESCRIPTION
GOV.UK PaaS is being decommissioned. Remove references to the service from our docs.