### PR TITLE
update optional frontmatter to use layouts

### DIFF
--- a/source/configure_project/frontmatter/index.html.md.erb
+++ b/source/configure_project/frontmatter/index.html.md.erb
@@ -128,7 +128,17 @@ layout: core
 This page does not have a sidebar.
 ```
 
+You can use layouts to group pages and customise your Table of Contents (ToC).  To create a layout, create a new ruby file in the `source/layouts` directory, for example `source/layouts/live_support.erb`.  
 
+Apply the template by including it in the frontmatter block of a pages. In this example, we're applying the `live_support` layout to the page:
+
+```rb
+---
+layout: live_support
+---
+```
+
+The `tech-docs-gem` also has [helper functions you can use to manage your Table of Contents](https://github.com/alphagov/tech-docs-gem?tab=readme-ov-file#table-of-contents-helper-functions).
 
 ### old_paths
 

--- a/source/configure_project/frontmatter/index.html.md.erb
+++ b/source/configure_project/frontmatter/index.html.md.erb
@@ -130,7 +130,7 @@ This page does not have a sidebar.
 
 You can use layouts to group pages and customise your Table of Contents (ToC).  To create a layout, create a new ruby file in the `source/layouts` directory, for example `source/layouts/live_support.erb`.  
 
-Apply the template by including it in the frontmatter block of a pages. In this example, we're applying the `live_support` layout to the page:
+Apply the template by including it in the frontmatter block of a page. In this example, we're applying the `live_support` layout to the page:
 
 ```rb
 ---


### PR DESCRIPTION
## What’s changed

Have added a note about layouts and table of contents functions, and linked out to the tech docs gem


