### PR TITLE
Updated README to link to new documentation site on Github Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Tech Docs Template Documentation
 
-This repository was previously used to generate the [documentation website for the Tech Docs Template][tdt-docs]. Following the decommissioning of PaaS that site is no longer live. The documentation remains available in this git repository, although it is no longer maintained.
+This repository was previously used to generate the [old documentation website for the Tech Docs Template][tdt-docs]. Following the decommissioning of PaaS that site is no longer live, but this codebase deploys to a similar [documentation website on Github Pages][tdt-ghp]. The documentation remains available in this git repository, although it is no longer maintained.
 
 ## Publishing changes
 
-GitHub Actions automatically publishes changes merged into the main branch of this repository.
+GitHub Actions automatically publishes changes merged into the main branch of this repository to the [Tech Docs Template documentation site on GIthub Pages][tdt-ghp].
 
 ## Code of conduct
 
@@ -17,3 +17,4 @@ Unless stated otherwise, the codebase is released under the [MIT License](LICENS
 The documentation is [© Crown copyright](http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/) and available under the terms of the [Open Government 3.0 licence](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).
 
 [tdt-docs]: https://tdt-documentation.london.cloudapps.digital
+[tdt-ghp]: https://alphagov.github.io/tdt-documentation/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tech Docs Template Documentation
 
-This repository was previously used to generate the [old documentation website for the Tech Docs Template][tdt-docs]. Following the decommissioning of PaaS that site is no longer live, but this codebase deploys to a similar [documentation website on Github Pages][tdt-ghp]. The documentation remains available in this git repository, although it is no longer maintained.
+This repository was previously used to generate the [old documentation website for the Tech Docs Template][tdt-docs]. Following the decommissioning of PaaS that site is no longer live, but this codebase deploys to a similar [documentation website on GitHub Pages][tdt-ghp]. The documentation remains available in this git repository, although it is no longer maintained.
 
 ## Publishing changes
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository was previously used to generate the [old documentation website f
 
 ## Publishing changes
 
-GitHub Actions automatically publishes changes merged into the main branch of this repository to the [Tech Docs Template documentation site on GIthub Pages][tdt-ghp].
+GitHub Actions automatically publishes changes merged into the main branch of this repository to the [Tech Docs Template documentation site on GitHub Pages][tdt-ghp].
 
 ## Code of conduct
 


### PR DESCRIPTION
Updated README to link to new documentation site on Github Pages.

## Proposed changes

### What changed

Linked to the Github Pages site that replaces the old GovPaas one

## Related issue or tracking reference

- Fixes #223

## Checklist

Before you request approval you should confirm that:

- [x] the pull request has a clear title with a short description about the update in the documentation
- [ ] GitHub actions all pass
- [ ] you have tested the changes with a fresh build against the latest version of the `tech-docs-gem`
- [x] you have linked this PR to an issue (or explained why none exists)
- [ ] you have updated documentation if needed